### PR TITLE
Add Revolutionaries Faction

### DIFF
--- a/addons/revolutionaries/$PBOPREFIX$
+++ b/addons/revolutionaries/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacu\addons\revolutionaries

--- a/addons/revolutionaries/CfgFactionClasses.hpp
+++ b/addons/revolutionaries/CfgFactionClasses.hpp
@@ -1,0 +1,48 @@
+class CfgFactionClasses {
+    class TACU_Revolutionaries_O {
+        displayName = "Revolutionaries";
+        side = 0;
+        priority = 2;
+    };
+	
+	 class TACU_Revolutionaries_I {
+        displayName = "Civil Defense";
+        side = 2;
+        priority = 2;
+    };
+};
+
+class CfgEditorSubcategories {
+    class TACU_Revolutionaries_EdSubCat_O_Tanoan {
+        displayName = "Men (Tanoan)";
+    };
+
+    class TACU_Revolutionaries_EdSubCat_O_Russian {
+        displayName = "Men (Russian)";
+    };
+
+    class TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa {
+        displayName = "Cars (Tanoan)";
+    };
+
+    class TACU_Revolutionaries_EdSubCat_O_Cars_Russian {
+        displayName = "Cars (Russian)";
+    };
+
+	class TACU_Revolutionaries_EdSubCat_I_Tanoan{
+		displayName = "Men (Tanoan)";
+	};
+
+    class TACU_Revolutionaries_EdSubCat_I_Russian {
+        displayName = "Men (Russian)";
+    };
+	
+	    class TACU_Revolutionaries_EdSubCat_I_Cars_Tanoa {
+        displayName = "Cars (Tanoan)";
+    };
+
+    class TACU_Revolutionaries_EdSubCat_I_Cars_Russian {
+        displayName = "Cars (Russian)";
+    };
+	
+};

--- a/addons/revolutionaries/CfgFactionClasses.hpp
+++ b/addons/revolutionaries/CfgFactionClasses.hpp
@@ -4,45 +4,35 @@ class CfgFactionClasses {
         side = 0;
         priority = 2;
     };
-	
-	 class TACU_Revolutionaries_I {
+    class TACU_Revolutionaries_I {
         displayName = "Civil Defense";
         side = 2;
         priority = 2;
     };
 };
-
 class CfgEditorSubcategories {
     class TACU_Revolutionaries_EdSubCat_O_Tanoan {
         displayName = "Men (Tanoan)";
     };
-
     class TACU_Revolutionaries_EdSubCat_O_Russian {
         displayName = "Men (Russian)";
     };
-
     class TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa {
         displayName = "Cars (Tanoan)";
     };
-
     class TACU_Revolutionaries_EdSubCat_O_Cars_Russian {
         displayName = "Cars (Russian)";
     };
-
-	class TACU_Revolutionaries_EdSubCat_I_Tanoan{
+    class TACU_Revolutionaries_EdSubCat_I_Tanoan {
 		displayName = "Men (Tanoan)";
-	};
-
+    };
     class TACU_Revolutionaries_EdSubCat_I_Russian {
         displayName = "Men (Russian)";
     };
-	
-	    class TACU_Revolutionaries_EdSubCat_I_Cars_Tanoa {
+    class TACU_Revolutionaries_EdSubCat_I_Cars_Tanoa {
         displayName = "Cars (Tanoan)";
     };
-
     class TACU_Revolutionaries_EdSubCat_I_Cars_Russian {
         displayName = "Cars (Russian)";
     };
-	
 };

--- a/addons/revolutionaries/CfgGroups.hpp
+++ b/addons/revolutionaries/CfgGroups.hpp
@@ -1,0 +1,9 @@
+class CfgGroups {  
+  class EAST {
+        #include "CfgGroups_East.hpp"
+    };
+
+    class INDEP {
+        #include "CfgGroups_Indep.hpp"
+    };
+};

--- a/addons/revolutionaries/CfgGroups.hpp
+++ b/addons/revolutionaries/CfgGroups.hpp
@@ -2,7 +2,6 @@ class CfgGroups {
   class EAST {
         #include "CfgGroups_East.hpp"
     };
-
     class INDEP {
         #include "CfgGroups_Indep.hpp"
     };

--- a/addons/revolutionaries/CfgGroups_East.hpp
+++ b/addons/revolutionaries/CfgGroups_East.hpp
@@ -55,7 +55,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {5, -5, 0};
             };
-        };				
+        };
         class TACU_Revolutionaries_G_O_Tanoan_FTeamL {
             name = "Fireteam (Light)";
             side = 0;
@@ -85,7 +85,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {10, -5, 0};
             };
-        };	
+        };
         class TACU_Revolutionaries_G_O_Tanoan_FTeamH {
             name = "Fireteam (Heavy)";
             side = 0;
@@ -157,7 +157,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {15, -5, 0};
             };
-        };	
+        };
         class TACU_Revolutionaries_G_O_Tanoan_SquadH {
             name = "Squad (Heavy)";
             side = 0;
@@ -199,7 +199,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {15, -5, 0};
             };
-        };	
+        };
         class TACU_Revolutionaries_G_O_Tanoan_SupportL {
             name = "Support (Light)";
             side = 0;
@@ -222,13 +222,13 @@ class TACU_Revolutionaries_O {
                 side = 0;
                 rank = "PRIVATE";
                 position[] = {-5, -5, 0};
-	            };
+                };
             class unit3 {
                 vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman06";
                 side = 0;
                 rank = "PRIVATE";
                 position[] = {10, -5, 0}
-			};
+            };
         };
         class TACU_Revolutionaries_G_O_Tanoan_SupportH {
             name = "Support (Heavy)";
@@ -252,18 +252,17 @@ class TACU_Revolutionaries_O {
                 side = 0;
                 rank = "PRIVATE";
                 position[] = {-5, -5, 0};
-			};
+            };
             class unit3 {
                 vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman06";
                 side = 0;
                 rank = "PRIVATE";
                 position[] = {10, -5, 0}
-			};			
+            };
         };
-	 };
+     };
     class TACU_Revolutionaries_G_O_Russian { //Russian
         name = "Revolutionaries (Russian)";
-
         class TACU_Revolutionaries_G_O_Russian_GuardL {
             name = "Guards (Light)";
             side = 0;
@@ -281,7 +280,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {5, -5, 0};
             };
-        };		
+        };
         class TACU_Revolutionaries_G_O_Russian_GuardH {
             name = "Guards (Heavy)";
             side = 0;
@@ -299,7 +298,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {5, -5, 0};
             };
-        };	
+        };
         class TACU_Revolutionaries_G_O_Russian_FTeamL {
             name = "Fireteam (Light)";
             side = 0;
@@ -329,7 +328,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {10, -5, 0};
             };
-        };	
+        };
         class TACU_Revolutionaries_G_O_Russian_FTeamH {
             name = "Fireteam (Heavy)";
             side = 0;
@@ -359,7 +358,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {10, -5, 0};
             };
-        };		
+        };
         class TACU_Revolutionaries_G_O_Russian_SquadL {
             name = "Squad (Light)";
             side = 0;
@@ -401,7 +400,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {15, -5, 0};
             };
-        };	
+        };
         class TACU_Revolutionaries_G_O_Russian_SquadH {
             name = "Squad (Heavy)";
             side = 0;
@@ -443,7 +442,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {15, -5, 0};
             };
-        };	
+        };
         class TACU_Revolutionaries_G_O_Russian_SupportL {
             name = "Support (Light)";
             side = 0;
@@ -466,13 +465,13 @@ class TACU_Revolutionaries_O {
                 side = 0;
                 rank = "PRIVATE";
                 position[] = {-5, -5, 0};
-	            };
+                };
             class unit3 {
                 vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman06";
                 side = 0;
                 rank = "PRIVATE";
                 position[] = {10, -5, 0}
-			};
+            };
         };
         class TACU_Revolutionaries_G_O_Russian_SniperT {
             name = "Sniper Team";
@@ -514,13 +513,13 @@ class TACU_Revolutionaries_O {
                 side = 0;
                 rank = "PRIVATE";
                 position[] = {-5, -5, 0};
-			};
+            };
             class unit3 {
                 vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman06";
                 side = 0;
                 rank = "PRIVATE";
                 position[] = {10, -5, 0}
-			};			
-        };		
+            };
+        };
     };
 };

--- a/addons/revolutionaries/CfgGroups_East.hpp
+++ b/addons/revolutionaries/CfgGroups_East.hpp
@@ -1,0 +1,544 @@
+class TACU_Revolutionaries_O {
+    name = "Revolutionaries";
+    class TACU_Revolutionaries_G_O_Tanoan {
+        name = "Revolutionaries (Tanoan)";
+
+        class TACU_Revolutionaries_G_O_Tanoan_GuardL {
+            name = "Guards (Light)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman02";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Tanoan_GuardH {
+            name = "Guards (Heavy)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Base";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman01";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Tanoan_SniperT {
+            name = "Sniper Team";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman04";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+        };		
+		
+        class TACU_Revolutionaries_G_O_Tanoan_FTeamL {
+            name = "Fireteam (Light)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman02";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman01";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman04";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Tanoan_FTeamH {
+            name = "Fireteam (Heavy)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman10";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman07";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Base";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman09";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Tanoan_SquadL {
+            name = "Squad (Light)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman02";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman01";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman04";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+            class unit4 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman08";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-10, -5, 0};
+            };
+            class unit5 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Base";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {15, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Tanoan_SquadH {
+            name = "Squad (Heavy)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman10";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman07";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman01";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman09";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+            class unit4 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Base";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-10, -5, 0};
+            };
+            class unit5 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman10";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {15, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Tanoan_SupportL {
+            name = "Support (Light)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman07";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman08";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+	            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman06";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0}
+			};
+        };
+
+        class TACU_Revolutionaries_G_O_Tanoan_SupportH {
+            name = "Support (Heavy)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Base";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman09";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman10";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+			};
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Tanoan_Rifleman06";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0}
+			};			
+        };
+	 };
+//Russian
+    class TACU_Revolutionaries_G_O_Russian {
+        name = "Revolutionaries (Russian)";
+
+        class TACU_Revolutionaries_G_O_Russian_GuardL {
+            name = "Guards (Light)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman02";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Russian_GuardH {
+            name = "Guards (Heavy)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Base";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman01";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Russian_FTeamL {
+            name = "Fireteam (Light)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman02";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman01";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman04";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Russian_FTeamH {
+            name = "Fireteam (Heavy)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman10";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman07";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Base";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman09";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Russian_SquadL {
+            name = "Squad (Light)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman02";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman01";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman04";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+            class unit4 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman08";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-10, -5, 0};
+            };
+            class unit5 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Base";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {15, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Russian_SquadH {
+            name = "Squad (Heavy)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman10";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman07";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman01";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman09";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+            class unit4 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Base";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-10, -5, 0};
+            };
+            class unit5 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman10";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {15, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_O_Russian_SupportL {
+            name = "Support (Light)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman07";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman08";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+	            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman06";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0}
+			};
+        };
+
+        class TACU_Revolutionaries_G_O_Russian_SniperT {
+            name = "Sniper Team";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman04";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+        };	
+
+        class TACU_Revolutionaries_G_O_Russian_SupportH {
+            name = "Support (Heavy)";
+            side = 0;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Base";
+                side = 0;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman09";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman10";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+			};
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_O_Russian_Rifleman06";
+                side = 0;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0}
+			};			
+        };		
+};
+};

--- a/addons/revolutionaries/CfgGroups_East.hpp
+++ b/addons/revolutionaries/CfgGroups_East.hpp
@@ -1,8 +1,7 @@
 class TACU_Revolutionaries_O {
     name = "Revolutionaries";
-    class TACU_Revolutionaries_G_O_Tanoan {
+    class TACU_Revolutionaries_G_O_Tanoan { //Tanoan
         name = "Revolutionaries (Tanoan)";
-
         class TACU_Revolutionaries_G_O_Tanoan_GuardL {
             name = "Guards (Light)";
             side = 0;
@@ -21,7 +20,6 @@ class TACU_Revolutionaries_O {
                 position[] = {5, -5, 0};
             };
         };
-		
         class TACU_Revolutionaries_G_O_Tanoan_GuardH {
             name = "Guards (Heavy)";
             side = 0;
@@ -40,7 +38,6 @@ class TACU_Revolutionaries_O {
                 position[] = {5, -5, 0};
             };
         };
-		
         class TACU_Revolutionaries_G_O_Tanoan_SniperT {
             name = "Sniper Team";
             side = 0;
@@ -58,8 +55,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {5, -5, 0};
             };
-        };		
-		
+        };				
         class TACU_Revolutionaries_G_O_Tanoan_FTeamL {
             name = "Fireteam (Light)";
             side = 0;
@@ -89,8 +85,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {10, -5, 0};
             };
-        };
-		
+        };	
         class TACU_Revolutionaries_G_O_Tanoan_FTeamH {
             name = "Fireteam (Heavy)";
             side = 0;
@@ -121,7 +116,6 @@ class TACU_Revolutionaries_O {
                 position[] = {10, -5, 0};
             };
         };
-		
         class TACU_Revolutionaries_G_O_Tanoan_SquadL {
             name = "Squad (Light)";
             side = 0;
@@ -163,8 +157,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {15, -5, 0};
             };
-        };
-		
+        };	
         class TACU_Revolutionaries_G_O_Tanoan_SquadH {
             name = "Squad (Heavy)";
             side = 0;
@@ -206,8 +199,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {15, -5, 0};
             };
-        };
-		
+        };	
         class TACU_Revolutionaries_G_O_Tanoan_SupportL {
             name = "Support (Light)";
             side = 0;
@@ -238,7 +230,6 @@ class TACU_Revolutionaries_O {
                 position[] = {10, -5, 0}
 			};
         };
-
         class TACU_Revolutionaries_G_O_Tanoan_SupportH {
             name = "Support (Heavy)";
             side = 0;
@@ -270,8 +261,7 @@ class TACU_Revolutionaries_O {
 			};			
         };
 	 };
-//Russian
-    class TACU_Revolutionaries_G_O_Russian {
+    class TACU_Revolutionaries_G_O_Russian { //Russian
         name = "Revolutionaries (Russian)";
 
         class TACU_Revolutionaries_G_O_Russian_GuardL {
@@ -291,8 +281,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {5, -5, 0};
             };
-        };
-		
+        };		
         class TACU_Revolutionaries_G_O_Russian_GuardH {
             name = "Guards (Heavy)";
             side = 0;
@@ -310,8 +299,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {5, -5, 0};
             };
-        };
-		
+        };	
         class TACU_Revolutionaries_G_O_Russian_FTeamL {
             name = "Fireteam (Light)";
             side = 0;
@@ -341,8 +329,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {10, -5, 0};
             };
-        };
-		
+        };	
         class TACU_Revolutionaries_G_O_Russian_FTeamH {
             name = "Fireteam (Heavy)";
             side = 0;
@@ -372,8 +359,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {10, -5, 0};
             };
-        };
-		
+        };		
         class TACU_Revolutionaries_G_O_Russian_SquadL {
             name = "Squad (Light)";
             side = 0;
@@ -415,8 +401,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {15, -5, 0};
             };
-        };
-		
+        };	
         class TACU_Revolutionaries_G_O_Russian_SquadH {
             name = "Squad (Heavy)";
             side = 0;
@@ -458,8 +443,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {15, -5, 0};
             };
-        };
-		
+        };	
         class TACU_Revolutionaries_G_O_Russian_SupportL {
             name = "Support (Light)";
             side = 0;
@@ -490,7 +474,6 @@ class TACU_Revolutionaries_O {
                 position[] = {10, -5, 0}
 			};
         };
-
         class TACU_Revolutionaries_G_O_Russian_SniperT {
             name = "Sniper Team";
             side = 0;
@@ -508,8 +491,7 @@ class TACU_Revolutionaries_O {
                 rank = "PRIVATE";
                 position[] = {5, -5, 0};
             };
-        };	
-
+        };
         class TACU_Revolutionaries_G_O_Russian_SupportH {
             name = "Support (Heavy)";
             side = 0;
@@ -540,5 +522,5 @@ class TACU_Revolutionaries_O {
                 position[] = {10, -5, 0}
 			};			
         };		
-};
+    };
 };

--- a/addons/revolutionaries/CfgGroups_Indep.hpp
+++ b/addons/revolutionaries/CfgGroups_Indep.hpp
@@ -221,5 +221,5 @@ class TACU_Revolutionaries_I {
                 position[] = {15, -5, 0};
             };
         };
-	};
+    };
 };

--- a/addons/revolutionaries/CfgGroups_Indep.hpp
+++ b/addons/revolutionaries/CfgGroups_Indep.hpp
@@ -1,0 +1,236 @@
+class TACU_Revolutionaries_I {
+    name = "Civil Defense";
+    class TACU_Revolutionaries_G_I_Tanoan {
+        name = "Civil Defense (Tanoan)";
+
+        class TACU_Revolutionaries_G_I_Tanoan_GuardL {
+            name = "Guards";
+            side = 2;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman04";
+                side = 2;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman02";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+        };
+		
+	
+        class TACU_Revolutionaries_G_I_Tanoan_SniperT {
+            name = "Sniper Team";
+            side = 2;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman03";
+                side = 2;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman04";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+        };		
+		
+        class TACU_Revolutionaries_G_I_Tanoan_FTeamL {
+            name = "Fireteam";
+            side = 2;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman01";
+                side = 2;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman02";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman04";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Base";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_I_Tanoan_SquadL {
+            name = "Squad";
+            side = 2;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman01";
+                side = 2;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman02";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman04";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Base";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+            class unit4 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman02";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {-10, -5, 0};
+            };
+            class unit5 {
+                vehicle = "TACU_Revolutionaries_U_I_Tanoan_Rifleman04";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {15, -5, 0};
+            };
+        };
+ };
+//Russian
+     class TACU_Revolutionaries_G_I_Russian {
+        name = "Civil Defense (Russian)";
+
+        class TACU_Revolutionaries_G_I_Russian_GuardL {
+            name = "Guards";
+            side = 2;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
+                side = 2;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman02";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+        };
+		
+	
+        class TACU_Revolutionaries_G_I_Russian_SniperT {
+            name = "Sniper Team";
+            side = 2;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman03";
+                side = 2;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+        };		
+		
+        class TACU_Revolutionaries_G_I_Russian_FTeamL {
+            name = "Fireteam";
+            side = 2;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman01";
+                side = 2;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman02";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Base";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+        };
+		
+        class TACU_Revolutionaries_G_I_Russian_SquadL {
+            name = "Squad";
+            side = 2;
+            faction = "TACU_Revolutionaries_O";
+            icon = "\a3\ui_f\data\map\markers\nato\o_inf.paa";
+            class unit0 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman01";
+                side = 2;
+                rank = "SERGEANT";
+                position[] = {0, 0, 0};
+            };
+            class unit1 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman02";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {5, -5, 0};
+            };
+            class unit2 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {-5, -5, 0};
+            };
+            class unit3 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Base";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {10, -5, 0};
+            };
+            class unit4 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman02";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {-10, -5, 0};
+            };
+            class unit5 {
+                vehicle = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
+                side = 2;
+                rank = "PRIVATE";
+                position[] = {15, -5, 0};
+            };
+        };
+	 };
+};

--- a/addons/revolutionaries/CfgGroups_Indep.hpp
+++ b/addons/revolutionaries/CfgGroups_Indep.hpp
@@ -1,8 +1,7 @@
 class TACU_Revolutionaries_I {
     name = "Civil Defense";
-    class TACU_Revolutionaries_G_I_Tanoan {
+    class TACU_Revolutionaries_G_I_Tanoan { //Tanoan
         name = "Civil Defense (Tanoan)";
-
         class TACU_Revolutionaries_G_I_Tanoan_GuardL {
             name = "Guards";
             side = 2;
@@ -21,8 +20,6 @@ class TACU_Revolutionaries_I {
                 position[] = {5, -5, 0};
             };
         };
-		
-	
         class TACU_Revolutionaries_G_I_Tanoan_SniperT {
             name = "Sniper Team";
             side = 2;
@@ -40,8 +37,7 @@ class TACU_Revolutionaries_I {
                 rank = "PRIVATE";
                 position[] = {5, -5, 0};
             };
-        };		
-		
+        };
         class TACU_Revolutionaries_G_I_Tanoan_FTeamL {
             name = "Fireteam";
             side = 2;
@@ -71,8 +67,7 @@ class TACU_Revolutionaries_I {
                 rank = "PRIVATE";
                 position[] = {10, -5, 0};
             };
-        };
-		
+        };	
         class TACU_Revolutionaries_G_I_Tanoan_SquadL {
             name = "Squad";
             side = 2;
@@ -115,11 +110,9 @@ class TACU_Revolutionaries_I {
                 position[] = {15, -5, 0};
             };
         };
- };
-//Russian
-     class TACU_Revolutionaries_G_I_Russian {
+    };
+    class TACU_Revolutionaries_G_I_Russian { //Russian
         name = "Civil Defense (Russian)";
-
         class TACU_Revolutionaries_G_I_Russian_GuardL {
             name = "Guards";
             side = 2;
@@ -138,8 +131,6 @@ class TACU_Revolutionaries_I {
                 position[] = {5, -5, 0};
             };
         };
-		
-	
         class TACU_Revolutionaries_G_I_Russian_SniperT {
             name = "Sniper Team";
             side = 2;
@@ -157,8 +148,7 @@ class TACU_Revolutionaries_I {
                 rank = "PRIVATE";
                 position[] = {5, -5, 0};
             };
-        };		
-		
+        };
         class TACU_Revolutionaries_G_I_Russian_FTeamL {
             name = "Fireteam";
             side = 2;
@@ -189,7 +179,6 @@ class TACU_Revolutionaries_I {
                 position[] = {10, -5, 0};
             };
         };
-		
         class TACU_Revolutionaries_G_I_Russian_SquadL {
             name = "Squad";
             side = 2;
@@ -232,5 +221,5 @@ class TACU_Revolutionaries_I {
                 position[] = {15, -5, 0};
             };
         };
-	 };
+	};
 };

--- a/addons/revolutionaries/CfgVehicles.hpp
+++ b/addons/revolutionaries/CfgVehicles.hpp
@@ -1,106 +1,74 @@
 class CfgVehicles {
-    // Base Classes
-    class TACU_Main_U_OPFOR_Soldier_Base;
-	class TACU_Main_U_INDEP_Soldier_Base;
-  #include "CfgVehicles_Tanoan.hpp"
-  #include "CfgVehicles_Russian.hpp"
-  #include "CfgVehicles_TanoanHD.hpp"
-  #include "CfgVehicles_RussianHD.hpp"
-  #include "CfgVehicles_Vehicles.hpp"
-  
- //Backpacks
-    class B_FieldPack_blk;
-	    class TACU_Revolutionaries_Backpack_Mk14: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        {
-         MACRO_ADDMAGAZINE(10Rnd_Mk14_762x51_Mag,8);
+    #include "CfgVehicles_Tanoan.hpp"
+    #include "CfgVehicles_Russian.hpp"
+    #include "CfgVehicles_TanoanHD.hpp"
+    #include "CfgVehicles_RussianHD.hpp"
+    #include "CfgVehicles_Vehicles.hpp"
+    class B_FieldPack_blk; //Backpacks
+    class TACU_Revolutionaries_Backpack_Mk14: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(10Rnd_Mk14_762x51_Mag,8);
         };
 	};
-	
-	   class TACU_Revolutionaries_Backpack_Shotgun: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        { 
-          MACRO_ADDMAGAZINE(2Rnd_12Gauge_Pellets,16);
+    class TACU_Revolutionaries_Backpack_Shotgun: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines { 
+            MACRO_ADDMAGAZINE(2Rnd_12Gauge_Pellets,16);
         };
 	};
-	
-	
-	   class TACU_Revolutionaries_Backpack_MP5K: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        {
-         MACRO_ADDMAGAZINE(30Rnd_9x21_Mag_SMG_02,8);
+    class TACU_Revolutionaries_Backpack_MP5K: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(30Rnd_9x21_Mag_SMG_02,8);
         };
 	};
-	
-	
-	   class TACU_Revolutionaries_Backpack_CZ550: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        {
-          MACRO_ADDMAGAZINE(CUP_5x_22_LR_17_HMR_M,8);
+    class TACU_Revolutionaries_Backpack_CZ550: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(CUP_5x_22_LR_17_HMR_M,8);
         };
 	};
-	
-	
-	   class TACU_Revolutionaries_Backpack_LeeEnfield: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        {
-          MACRO_ADDMAGAZINE(CUP_10x_303_M,8);
+    class TACU_Revolutionaries_Backpack_LeeEnfield: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines {
+        MACRO_ADDMAGAZINE(CUP_10x_303_M,8);
         };
 	};
- 
- 	   class TACU_Revolutionaries_Backpack_M79: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        {
-          MACRO_ADDMAGAZINE(1Rnd_HE_Grenade_shell,10);
+    class TACU_Revolutionaries_Backpack_M79: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(1Rnd_HE_Grenade_shell,10);
         };
 	};
-	
-		   class TACU_Revolutionaries_Backpack_Bizon: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        {
-          MACRO_ADDMAGAZINE(CUP_64Rnd_9x19_Bizon_M,8);
+    class TACU_Revolutionaries_Backpack_Bizon: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(CUP_64Rnd_9x19_Bizon_M,8);
         };
 	};
-	
-		   class TACU_Revolutionaries_Backpack_UK59: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        {
-          MACRO_ADDMAGAZINE(CUP_50Rnd_UK59_762x54R_Tracer,8);
+    class TACU_Revolutionaries_Backpack_UK59: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(CUP_50Rnd_UK59_762x54R_Tracer,8);
         };
 	};
-    
-			   class TACU_Revolutionaries_Backpack_FNMinimiSPW: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        {
-          MACRO_ADDMAGAZINE(200Rnd_556x45_Box_F,5);
+    class TACU_Revolutionaries_Backpack_FNMinimiSPW: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(200Rnd_556x45_Box_F,5);
         };
 	};
-	
-			   class TACU_Revolutionaries_Backpack_FNFAL: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        {
-          MACRO_ADDMAGAZINE(CUP_20Rnd_762x51_FNFAL_M,8);
+    class TACU_Revolutionaries_Backpack_FNFAL: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(CUP_20Rnd_762x51_FNFAL_M,8);
+            };
+	};
+    class TACU_Revolutionaries_Backpack_CZ805A2: B_FieldPack_blk {
+        scope = 1;      
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(CUP_30Rnd_556x45_G36,8);
         };
 	};
-	
-	
-	 class TACU_Revolutionaries_Backpack_CZ805A2: B_FieldPack_blk {
-         scope = 1;      
-        class TransportMagazines
-        {
-          MACRO_ADDMAGAZINE(CUP_30Rnd_556x45_G36,8);
-        };
-	};
-
-	
 };

--- a/addons/revolutionaries/CfgVehicles.hpp
+++ b/addons/revolutionaries/CfgVehicles.hpp
@@ -1,0 +1,106 @@
+class CfgVehicles {
+    // Base Classes
+    class TACU_Main_U_OPFOR_Soldier_Base;
+	class TACU_Main_U_INDEP_Soldier_Base;
+  #include "CfgVehicles_Tanoan.hpp"
+  #include "CfgVehicles_Russian.hpp"
+  #include "CfgVehicles_TanoanHD.hpp"
+  #include "CfgVehicles_RussianHD.hpp"
+  #include "CfgVehicles_Vehicles.hpp"
+  
+ //Backpacks
+    class B_FieldPack_blk;
+	    class TACU_Revolutionaries_Backpack_Mk14: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        {
+         MACRO_ADDMAGAZINE(10Rnd_Mk14_762x51_Mag,8);
+        };
+	};
+	
+	   class TACU_Revolutionaries_Backpack_Shotgun: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        { 
+          MACRO_ADDMAGAZINE(2Rnd_12Gauge_Pellets,16);
+        };
+	};
+	
+	
+	   class TACU_Revolutionaries_Backpack_MP5K: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        {
+         MACRO_ADDMAGAZINE(30Rnd_9x21_Mag_SMG_02,8);
+        };
+	};
+	
+	
+	   class TACU_Revolutionaries_Backpack_CZ550: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        {
+          MACRO_ADDMAGAZINE(CUP_5x_22_LR_17_HMR_M,8);
+        };
+	};
+	
+	
+	   class TACU_Revolutionaries_Backpack_LeeEnfield: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        {
+          MACRO_ADDMAGAZINE(CUP_10x_303_M,8);
+        };
+	};
+ 
+ 	   class TACU_Revolutionaries_Backpack_M79: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        {
+          MACRO_ADDMAGAZINE(1Rnd_HE_Grenade_shell,10);
+        };
+	};
+	
+		   class TACU_Revolutionaries_Backpack_Bizon: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        {
+          MACRO_ADDMAGAZINE(CUP_64Rnd_9x19_Bizon_M,8);
+        };
+	};
+	
+		   class TACU_Revolutionaries_Backpack_UK59: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        {
+          MACRO_ADDMAGAZINE(CUP_50Rnd_UK59_762x54R_Tracer,8);
+        };
+	};
+    
+			   class TACU_Revolutionaries_Backpack_FNMinimiSPW: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        {
+          MACRO_ADDMAGAZINE(200Rnd_556x45_Box_F,5);
+        };
+	};
+	
+			   class TACU_Revolutionaries_Backpack_FNFAL: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        {
+          MACRO_ADDMAGAZINE(CUP_20Rnd_762x51_FNFAL_M,8);
+        };
+	};
+	
+	
+	 class TACU_Revolutionaries_Backpack_CZ805A2: B_FieldPack_blk {
+         scope = 1;      
+        class TransportMagazines
+        {
+          MACRO_ADDMAGAZINE(CUP_30Rnd_556x45_G36,8);
+        };
+	};
+
+	
+};

--- a/addons/revolutionaries/CfgVehicles.hpp
+++ b/addons/revolutionaries/CfgVehicles.hpp
@@ -10,65 +10,65 @@ class CfgVehicles {
         class TransportMagazines {
             MACRO_ADDMAGAZINE(10Rnd_Mk14_762x51_Mag,8);
         };
-	};
+    };
     class TACU_Revolutionaries_Backpack_Shotgun: B_FieldPack_blk {
         scope = 1;      
         class TransportMagazines { 
             MACRO_ADDMAGAZINE(2Rnd_12Gauge_Pellets,16);
         };
-	};
+    };
     class TACU_Revolutionaries_Backpack_MP5K: B_FieldPack_blk {
         scope = 1;      
         class TransportMagazines {
             MACRO_ADDMAGAZINE(30Rnd_9x21_Mag_SMG_02,8);
         };
-	};
+    };
     class TACU_Revolutionaries_Backpack_CZ550: B_FieldPack_blk {
         scope = 1;      
         class TransportMagazines {
             MACRO_ADDMAGAZINE(CUP_5x_22_LR_17_HMR_M,8);
         };
-	};
+    };
     class TACU_Revolutionaries_Backpack_LeeEnfield: B_FieldPack_blk {
         scope = 1;      
         class TransportMagazines {
         MACRO_ADDMAGAZINE(CUP_10x_303_M,8);
         };
-	};
+    };
     class TACU_Revolutionaries_Backpack_M79: B_FieldPack_blk {
         scope = 1;      
         class TransportMagazines {
             MACRO_ADDMAGAZINE(1Rnd_HE_Grenade_shell,10);
         };
-	};
+    };
     class TACU_Revolutionaries_Backpack_Bizon: B_FieldPack_blk {
         scope = 1;      
         class TransportMagazines {
             MACRO_ADDMAGAZINE(CUP_64Rnd_9x19_Bizon_M,8);
         };
-	};
+    };
     class TACU_Revolutionaries_Backpack_UK59: B_FieldPack_blk {
         scope = 1;      
         class TransportMagazines {
             MACRO_ADDMAGAZINE(CUP_50Rnd_UK59_762x54R_Tracer,8);
         };
-	};
+    };
     class TACU_Revolutionaries_Backpack_FNMinimiSPW: B_FieldPack_blk {
         scope = 1;      
         class TransportMagazines {
             MACRO_ADDMAGAZINE(200Rnd_556x45_Box_F,5);
         };
-	};
+    };
     class TACU_Revolutionaries_Backpack_FNFAL: B_FieldPack_blk {
         scope = 1;      
         class TransportMagazines {
             MACRO_ADDMAGAZINE(CUP_20Rnd_762x51_FNFAL_M,8);
-            };
-	};
+        };
+    };
     class TACU_Revolutionaries_Backpack_CZ805A2: B_FieldPack_blk {
         scope = 1;      
         class TransportMagazines {
             MACRO_ADDMAGAZINE(CUP_30Rnd_556x45_G36,8);
         };
-	};
+    };
 };

--- a/addons/revolutionaries/CfgVehicles_Russian.hpp
+++ b/addons/revolutionaries/CfgVehicles_Russian.hpp
@@ -1,0 +1,161 @@
+// Units - Revolutionaries (Russian)
+
+class TACU_Revolutionaries_U_O_Russian_Base: TACU_Main_U_OPFOR_Soldier_Base {
+    author = "Jack";
+    displayName = "Rifleman (FAL)";
+    faction = "TACU_Revolutionaries_O";
+    scope = 2;
+    scopeCurator = 2;
+    identityTypes[] = {"CUP_D_Language_RU", "Head_Euro", "G_Balaclava_blk"};
+    genericNames = "CUP_Names_RussianMen";
+    icon = "iconMan";
+    role = "Rifleman";
+    uniformClass = "CUP_U_C_Citizen_01";
+    backpack = "TACU_Revolutionaries_Backpack_FNFAL";
+    linkedItems[] = {"ItemWatch","ItemCompass","ItemMap"};
+    respawnLinkedItems[] = {"ItemWatch","ItemCompass","ItemMap"};
+    Items[] = {mag_5("ACE_fieldDressing"),"ACE_EarPlugs"};
+    respawnItems[] = {mag_5("ACE_fieldDressing"),"ACE_EarPlugs"};
+    weapons[] = {"CUP_arifle_FNFAL"};
+    respawnWeapons[] = {"CUP_arifle_FNFAL"};
+    magazines[] = {mag_2("CUP_20Rnd_762x51_FNFAL_M")};
+    respawnMagazines[] = {mag_2("CUP_20Rnd_762x51_FNFAL_M")};
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Russian";
+    // editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman.jpg);
+    headgearList[] = {};
+    TACU_allowedFacewear[] = {
+        "G_Balaclava_blk", 1
+    };
+};
+
+//Unit Specifics
+
+class TACU_Revolutionaries_U_O_Russian_Rifleman01: TACU_Revolutionaries_U_O_Russian_Base {
+    displayName = "Rifleman (MK14)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Citizen_02";
+    weapons[] = {"srifle_DMR_06_hunter_F"};
+    respawnWeapons[] = {"srifle_DMR_06_hunter_F"};
+    magazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
+    respawnMagazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
+	backpack = "TACU_Revolutionaries_Backpack_Mk14";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Russian_Rifleman02: TACU_Revolutionaries_U_O_Russian_Base {
+    displayName = "Shotgunner"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Citizen_03";
+    weapons[] = {"sgun_HunterShotgun_01_F"};
+    respawnWeapons[] = {"sgun_HunterShotgun_01_F"};
+    magazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
+    respawnMagazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
+	backpack = "TACU_Revolutionaries_Backpack_Shotgun";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Russian_Rifleman03: TACU_Revolutionaries_U_O_Russian_Base {
+    displayName = "Submachine Gunner (MP5K)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Citizen_04";
+    weapons[] = {"TACU_Revolutionaries_Weapon_O_MP5K"};
+    respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_MP5K"};
+    magazines[] = {mag_2("30Rnd_9x21_Mag_SMG_02")};
+    respawnMagazines[] = {mag_2("30Rnd_9x21_Mag_SMG_02")};
+	backpack = "TACU_Revolutionaries_Backpack_MP5K";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Russian_Rifleman04: TACU_Revolutionaries_U_O_Russian_Base {
+    displayName = "Marksmen"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Woodlander_04";
+    weapons[] = {"CUP_srifle_CZ550"};
+    respawnWeapons[] = {"CUP_srifle_CZ550"};
+    magazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
+    respawnMagazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
+	backpack = "TACU_Revolutionaries_Backpack_CZ550";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Russian_Rifleman05: TACU_Revolutionaries_U_O_Russian_Base {
+    displayName = "Rifleman (Lee Enfield)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Woodlander_03";
+    weapons[] = {"CUP_srifle_LeeEnfield"};
+    respawnWeapons[] = {"CUP_srifle_LeeEnfield"};
+    magazines[] = {mag_2("CUP_10x_303_M")};
+    respawnMagazines[] = {mag_2("CUP_10x_303_M")};
+	backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Russian_Rifleman06: TACU_Revolutionaries_U_O_Russian_Base {
+    displayName = "Grenadier"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Woodlander_02";
+    weapons[] = {"CUP_glaunch_M79"};
+    respawnWeapons[] = {"CUP_glaunch_M79"};
+    magazines[] = {mag_5("1Rnd_HE_Grenade_shell")};
+    respawnMagazines[] = {mag_5("1Rnd_HE_Grenade_shell")};
+	backpack = "TACU_Revolutionaries_Backpack_M79";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Russian_Rifleman07: TACU_Revolutionaries_U_O_Russian_Base {
+    displayName = "Submachine Gunner (Bizon)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Woodlander_01";
+    weapons[] = {"CUP_smg_bizon"};
+    respawnWeapons[] = {"CUP_smg_bizon"};
+    magazines[] = {mag_2("CUP_64Rnd_9x19_Bizon_M")};
+    respawnMagazines[] = {mag_2("CUP_64Rnd_9x19_Bizon_M")};
+	backpack = "TACU_Revolutionaries_Backpack_Bizon";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Russian_Rifleman08: TACU_Revolutionaries_U_O_Russian_Base {
+    displayName = "Machine Gunner (UK-59)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Worker_02";
+    weapons[] = {"CUP_lmg_UK59"};
+    respawnWeapons[] = {"CUP_lmg_UK59"};
+    magazines[] = {mag_2("CUP_50Rnd_UK59_762x54R_Tracer")};
+    respawnMagazines[] = {mag_2("CUP_50Rnd_UK59_762x54R_Tracer")};
+	backpack = "TACU_Revolutionaries_Backpack_UK59";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Russian_Rifleman09: TACU_Revolutionaries_U_O_Russian_Base {
+    displayName = "Machine Gunner (FN Minimi SPW)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Worker_03";
+    weapons[] = {"TACU_Revolutionaries_Weapon_O_FNMinimiSPW"};
+    respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_FNMinimiSPW"};
+    magazines[] = {"200Rnd_556x45_Box_F"};
+    respawnMagazines[] = {"200Rnd_556x45_Box_F"};
+	backpack = "TACU_Revolutionaries_Backpack_FNMinimiSPW";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Russian_Rifleman10: TACU_Revolutionaries_U_O_Russian_Base {
+    displayName = "Rifleman (CZ805 A2)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_O_R_Gorka_01_black_F";
+    weapons[] = {"TACU_Revolutionaries_Weapon_O_CZ805A2"};
+    respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_CZ805A2"};
+    magazines[] = {mag_2("CUP_30Rnd_556x45_G36")};
+    respawnMagazines[] = {mag_2("CUP_30Rnd_556x45_G36")};
+	backpack = "TACU_Revolutionaries_Backpack_CZ805A2";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};

--- a/addons/revolutionaries/CfgVehicles_Russian.hpp
+++ b/addons/revolutionaries/CfgVehicles_Russian.hpp
@@ -1,6 +1,4 @@
-// Units - Revolutionaries (Russian)
-
-class TACU_Revolutionaries_U_O_Russian_Base: TACU_Main_U_OPFOR_Soldier_Base {
+class TACU_Revolutionaries_U_O_Russian_Base: TACU_Main_U_OPFOR_Soldier_Base { // Units - Revolutionaries (Russian)
     author = "Jack";
     displayName = "Rifleman (FAL)";
     faction = "TACU_Revolutionaries_O";
@@ -27,10 +25,7 @@ class TACU_Revolutionaries_U_O_Russian_Base: TACU_Main_U_OPFOR_Soldier_Base {
         "G_Balaclava_blk", 1
     };
 };
-
-//Unit Specifics
-
-class TACU_Revolutionaries_U_O_Russian_Rifleman01: TACU_Revolutionaries_U_O_Russian_Base {
+class TACU_Revolutionaries_U_O_Russian_Rifleman01: TACU_Revolutionaries_U_O_Russian_Base { //Unit Specifics
     displayName = "Rifleman (MK14)"; 
     scope = 2;
     scopeCurator = 2;
@@ -39,10 +34,9 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman01: TACU_Revolutionaries_U_O_Russ
     respawnWeapons[] = {"srifle_DMR_06_hunter_F"};
     magazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
     respawnMagazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
-	backpack = "TACU_Revolutionaries_Backpack_Mk14";
+    backpack = "TACU_Revolutionaries_Backpack_Mk14";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Russian_Rifleman02: TACU_Revolutionaries_U_O_Russian_Base {
     displayName = "Shotgunner"; 
     scope = 2;
@@ -52,10 +46,9 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman02: TACU_Revolutionaries_U_O_Russ
     respawnWeapons[] = {"sgun_HunterShotgun_01_F"};
     magazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
     respawnMagazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
-	backpack = "TACU_Revolutionaries_Backpack_Shotgun";
+    backpack = "TACU_Revolutionaries_Backpack_Shotgun";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Russian_Rifleman03: TACU_Revolutionaries_U_O_Russian_Base {
     displayName = "Submachine Gunner (MP5K)"; 
     scope = 2;
@@ -65,10 +58,9 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman03: TACU_Revolutionaries_U_O_Russ
     respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_MP5K"};
     magazines[] = {mag_2("30Rnd_9x21_Mag_SMG_02")};
     respawnMagazines[] = {mag_2("30Rnd_9x21_Mag_SMG_02")};
-	backpack = "TACU_Revolutionaries_Backpack_MP5K";
+    backpack = "TACU_Revolutionaries_Backpack_MP5K";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Russian_Rifleman04: TACU_Revolutionaries_U_O_Russian_Base {
     displayName = "Marksmen"; 
     scope = 2;
@@ -78,10 +70,9 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman04: TACU_Revolutionaries_U_O_Russ
     respawnWeapons[] = {"CUP_srifle_CZ550"};
     magazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
     respawnMagazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
-	backpack = "TACU_Revolutionaries_Backpack_CZ550";
+    backpack = "TACU_Revolutionaries_Backpack_CZ550";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Russian_Rifleman05: TACU_Revolutionaries_U_O_Russian_Base {
     displayName = "Rifleman (Lee Enfield)"; 
     scope = 2;
@@ -91,10 +82,9 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman05: TACU_Revolutionaries_U_O_Russ
     respawnWeapons[] = {"CUP_srifle_LeeEnfield"};
     magazines[] = {mag_2("CUP_10x_303_M")};
     respawnMagazines[] = {mag_2("CUP_10x_303_M")};
-	backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
+    backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Russian_Rifleman06: TACU_Revolutionaries_U_O_Russian_Base {
     displayName = "Grenadier"; 
     scope = 2;
@@ -104,10 +94,9 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman06: TACU_Revolutionaries_U_O_Russ
     respawnWeapons[] = {"CUP_glaunch_M79"};
     magazines[] = {mag_5("1Rnd_HE_Grenade_shell")};
     respawnMagazines[] = {mag_5("1Rnd_HE_Grenade_shell")};
-	backpack = "TACU_Revolutionaries_Backpack_M79";
+    backpack = "TACU_Revolutionaries_Backpack_M79";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Russian_Rifleman07: TACU_Revolutionaries_U_O_Russian_Base {
     displayName = "Submachine Gunner (Bizon)"; 
     scope = 2;
@@ -117,10 +106,9 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman07: TACU_Revolutionaries_U_O_Russ
     respawnWeapons[] = {"CUP_smg_bizon"};
     magazines[] = {mag_2("CUP_64Rnd_9x19_Bizon_M")};
     respawnMagazines[] = {mag_2("CUP_64Rnd_9x19_Bizon_M")};
-	backpack = "TACU_Revolutionaries_Backpack_Bizon";
+    backpack = "TACU_Revolutionaries_Backpack_Bizon";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Russian_Rifleman08: TACU_Revolutionaries_U_O_Russian_Base {
     displayName = "Machine Gunner (UK-59)"; 
     scope = 2;
@@ -130,10 +118,9 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman08: TACU_Revolutionaries_U_O_Russ
     respawnWeapons[] = {"CUP_lmg_UK59"};
     magazines[] = {mag_2("CUP_50Rnd_UK59_762x54R_Tracer")};
     respawnMagazines[] = {mag_2("CUP_50Rnd_UK59_762x54R_Tracer")};
-	backpack = "TACU_Revolutionaries_Backpack_UK59";
+    backpack = "TACU_Revolutionaries_Backpack_UK59";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Russian_Rifleman09: TACU_Revolutionaries_U_O_Russian_Base {
     displayName = "Machine Gunner (FN Minimi SPW)"; 
     scope = 2;
@@ -143,10 +130,9 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman09: TACU_Revolutionaries_U_O_Russ
     respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_FNMinimiSPW"};
     magazines[] = {"200Rnd_556x45_Box_F"};
     respawnMagazines[] = {"200Rnd_556x45_Box_F"};
-	backpack = "TACU_Revolutionaries_Backpack_FNMinimiSPW";
+    backpack = "TACU_Revolutionaries_Backpack_FNMinimiSPW";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Russian_Rifleman10: TACU_Revolutionaries_U_O_Russian_Base {
     displayName = "Rifleman (CZ805 A2)"; 
     scope = 2;
@@ -156,6 +142,6 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman10: TACU_Revolutionaries_U_O_Russ
     respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_CZ805A2"};
     magazines[] = {mag_2("CUP_30Rnd_556x45_G36")};
     respawnMagazines[] = {mag_2("CUP_30Rnd_556x45_G36")};
-	backpack = "TACU_Revolutionaries_Backpack_CZ805A2";
+    backpack = "TACU_Revolutionaries_Backpack_CZ805A2";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };

--- a/addons/revolutionaries/CfgVehicles_RussianHD.hpp
+++ b/addons/revolutionaries/CfgVehicles_RussianHD.hpp
@@ -1,0 +1,83 @@
+//Home Defense (Russian)
+
+class TACU_Revolutionaries_U_I_Russian_Base: TACU_Main_U_INDEP_Soldier_Base {
+    author = "Jack";
+    displayName = "Rifleman (FAL)";
+    faction = "TACU_Revolutionaries_I";
+    scope = 2;
+    scopeCurator = 2;
+    identityTypes[] = {"CUP_D_Language_RU", "Head_Euro", "G_Balaclava_blk"};
+    genericNames = "CUP_Names_RussianMen";
+    icon = "iconMan";
+    role = "Rifleman";
+    uniformClass = "CUP_U_C_Citizen_01";
+    backpack = "TACU_Revolutionaries_Backpack_FNFAL";
+    linkedItems[] = {"ItemWatch","ItemCompass","ItemMap"};
+    respawnLinkedItems[] = {"ItemWatch","ItemCompass","ItemMap"};
+    Items[] = {mag_5("ACE_fieldDressing"),"ACE_EarPlugs"};
+    respawnItems[] = {mag_5("ACE_fieldDressing"),"ACE_EarPlugs"};
+    weapons[] = {"CUP_arifle_FNFAL"};
+    respawnWeapons[] = {"CUP_arifle_FNFAL"};
+    magazines[] = {mag_2("CUP_20Rnd_762x51_FNFAL_M")};
+    respawnMagazines[] = {mag_2("CUP_20Rnd_762x51_FNFAL_M")};
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Russian";
+    // editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman.jpg);
+    headgearList[] = {};
+    TACU_allowedFacewear[] = {
+        "None", 1
+    };
+};
+
+//Unit Specifics
+
+class TACU_Revolutionaries_U_I_Russian_Rifleman01: TACU_Revolutionaries_U_I_Russian_Base {
+    displayName = "Rifleman (MK14)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Citizen_02";
+    weapons[] = {"srifle_DMR_06_hunter_F"};
+    respawnWeapons[] = {"srifle_DMR_06_hunter_F"};
+    magazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
+    respawnMagazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
+	backpack = "TACU_Revolutionaries_Backpack_Mk14";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_I_Russian_Rifleman02: TACU_Revolutionaries_U_I_Russian_Base {
+    displayName = "Shotgunner"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Citizen_03";
+    weapons[] = {"sgun_HunterShotgun_01_F"};
+    respawnWeapons[] = {"sgun_HunterShotgun_01_F"};
+    magazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
+    respawnMagazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
+	backpack = "TACU_Revolutionaries_Backpack_Shotgun";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_I_Russian_Rifleman03: TACU_Revolutionaries_U_I_Russian_Base {
+    displayName = "Marksmen"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Woodlander_04";
+    weapons[] = {"CUP_srifle_CZ550"};
+    respawnWeapons[] = {"CUP_srifle_CZ550"};
+    magazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
+    respawnMagazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
+	backpack = "TACU_Revolutionaries_Backpack_CZ550";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_I_Russian_Rifleman04: TACU_Revolutionaries_U_I_Russian_Base {
+    displayName = "Rifleman (Lee Enfield)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "CUP_U_C_Woodlander_03";
+    weapons[] = {"CUP_srifle_LeeEnfield"};
+    respawnWeapons[] = {"CUP_srifle_LeeEnfield"};
+    magazines[] = {mag_2("CUP_10x_303_M")};
+    respawnMagazines[] = {mag_2("CUP_10x_303_M")};
+	backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};

--- a/addons/revolutionaries/CfgVehicles_RussianHD.hpp
+++ b/addons/revolutionaries/CfgVehicles_RussianHD.hpp
@@ -1,6 +1,4 @@
-//Home Defense (Russian)
-
-class TACU_Revolutionaries_U_I_Russian_Base: TACU_Main_U_INDEP_Soldier_Base {
+class TACU_Revolutionaries_U_I_Russian_Base: TACU_Main_U_INDEP_Soldier_Base { //Home Defense (Russian)
     author = "Jack";
     displayName = "Rifleman (FAL)";
     faction = "TACU_Revolutionaries_I";
@@ -27,10 +25,7 @@ class TACU_Revolutionaries_U_I_Russian_Base: TACU_Main_U_INDEP_Soldier_Base {
         "None", 1
     };
 };
-
-//Unit Specifics
-
-class TACU_Revolutionaries_U_I_Russian_Rifleman01: TACU_Revolutionaries_U_I_Russian_Base {
+class TACU_Revolutionaries_U_I_Russian_Rifleman01: TACU_Revolutionaries_U_I_Russian_Base { //Unit Specifics
     displayName = "Rifleman (MK14)"; 
     scope = 2;
     scopeCurator = 2;
@@ -39,10 +34,9 @@ class TACU_Revolutionaries_U_I_Russian_Rifleman01: TACU_Revolutionaries_U_I_Russ
     respawnWeapons[] = {"srifle_DMR_06_hunter_F"};
     magazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
     respawnMagazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
-	backpack = "TACU_Revolutionaries_Backpack_Mk14";
+    backpack = "TACU_Revolutionaries_Backpack_Mk14";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_I_Russian_Rifleman02: TACU_Revolutionaries_U_I_Russian_Base {
     displayName = "Shotgunner"; 
     scope = 2;
@@ -52,10 +46,9 @@ class TACU_Revolutionaries_U_I_Russian_Rifleman02: TACU_Revolutionaries_U_I_Russ
     respawnWeapons[] = {"sgun_HunterShotgun_01_F"};
     magazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
     respawnMagazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
-	backpack = "TACU_Revolutionaries_Backpack_Shotgun";
+    backpack = "TACU_Revolutionaries_Backpack_Shotgun";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_I_Russian_Rifleman03: TACU_Revolutionaries_U_I_Russian_Base {
     displayName = "Marksmen"; 
     scope = 2;
@@ -65,10 +58,9 @@ class TACU_Revolutionaries_U_I_Russian_Rifleman03: TACU_Revolutionaries_U_I_Russ
     respawnWeapons[] = {"CUP_srifle_CZ550"};
     magazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
     respawnMagazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
-	backpack = "TACU_Revolutionaries_Backpack_CZ550";
+    backpack = "TACU_Revolutionaries_Backpack_CZ550";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_I_Russian_Rifleman04: TACU_Revolutionaries_U_I_Russian_Base {
     displayName = "Rifleman (Lee Enfield)"; 
     scope = 2;
@@ -78,6 +70,6 @@ class TACU_Revolutionaries_U_I_Russian_Rifleman04: TACU_Revolutionaries_U_I_Russ
     respawnWeapons[] = {"CUP_srifle_LeeEnfield"};
     magazines[] = {mag_2("CUP_10x_303_M")};
     respawnMagazines[] = {mag_2("CUP_10x_303_M")};
-	backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
+    backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };

--- a/addons/revolutionaries/CfgVehicles_Tanoan.hpp
+++ b/addons/revolutionaries/CfgVehicles_Tanoan.hpp
@@ -1,6 +1,4 @@
-// Units - Revolutionaries (Tanoan)
-
-class TACU_Revolutionaries_U_O_Tanoan_Base: TACU_Main_U_OPFOR_Soldier_Base {
+class TACU_Revolutionaries_U_O_Tanoan_Base: TACU_Main_U_OPFOR_Soldier_Base { // Units - Revolutionaries (Tanoan)
     author = "Jack";
     displayName = "Rifleman (FAL)";
     faction = "TACU_Revolutionaries_O";
@@ -27,10 +25,7 @@ class TACU_Revolutionaries_U_O_Tanoan_Base: TACU_Main_U_OPFOR_Soldier_Base {
         "G_Balaclava_blk", 1
     };
 };
-
-//Unit Specifics
-
-class TACU_Revolutionaries_U_O_Tanoan_Rifleman01: TACU_Revolutionaries_U_O_Tanoan_Base {
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman01: TACU_Revolutionaries_U_O_Tanoan_Base { //Unit Specifics
     displayName = "Rifleman (MK14)"; 
     scope = 2;
     scopeCurator = 2;
@@ -39,10 +34,9 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman01: TACU_Revolutionaries_U_O_Tanoa
     respawnWeapons[] = {"srifle_DMR_06_hunter_F"};
     magazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
     respawnMagazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
-	backpack = "TACU_Revolutionaries_Backpack_Mk14";
+    backpack = "TACU_Revolutionaries_Backpack_Mk14";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Tanoan_Rifleman02: TACU_Revolutionaries_U_O_Tanoan_Base {
     displayName = "Shotgunner"; 
     scope = 2;
@@ -52,10 +46,9 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman02: TACU_Revolutionaries_U_O_Tanoa
     respawnWeapons[] = {"sgun_HunterShotgun_01_F"};
     magazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
     respawnMagazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
-	backpack = "TACU_Revolutionaries_Backpack_Shotgun";
+    backpack = "TACU_Revolutionaries_Backpack_Shotgun";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Tanoan_Rifleman03: TACU_Revolutionaries_U_O_Tanoan_Base {
     displayName = "Submachine Gunner (MP5K)"; 
     scope = 2;
@@ -65,10 +58,9 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman03: TACU_Revolutionaries_U_O_Tanoa
     respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_MP5K"};
     magazines[] = {mag_2("30Rnd_9x21_Mag_SMG_02")};
     respawnMagazines[] = {mag_2("30Rnd_9x21_Mag_SMG_02")};
-	backpack = "TACU_Revolutionaries_Backpack_MP5K";
+    backpack = "TACU_Revolutionaries_Backpack_MP5K";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Tanoan_Rifleman04: TACU_Revolutionaries_U_O_Tanoan_Base {
     displayName = "Marksmen"; 
     scope = 2;
@@ -78,10 +70,9 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman04: TACU_Revolutionaries_U_O_Tanoa
     respawnWeapons[] = {"CUP_srifle_CZ550"};
     magazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
     respawnMagazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
-	backpack = "TACU_Revolutionaries_Backpack_CZ550";
+    backpack = "TACU_Revolutionaries_Backpack_CZ550";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Tanoan_Rifleman05: TACU_Revolutionaries_U_O_Tanoan_Base {
     displayName = "Rifleman (Lee Enfield)"; 
     scope = 2;
@@ -91,10 +82,9 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman05: TACU_Revolutionaries_U_O_Tanoa
     respawnWeapons[] = {"CUP_srifle_LeeEnfield"};
     magazines[] = {mag_2("CUP_10x_303_M")};
     respawnMagazines[] = {mag_2("CUP_10x_303_M")};
-	backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
+    backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Tanoan_Rifleman06: TACU_Revolutionaries_U_O_Tanoan_Base {
     displayName = "Grenadier"; 
     scope = 2;
@@ -104,10 +94,9 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman06: TACU_Revolutionaries_U_O_Tanoa
     respawnWeapons[] = {"CUP_glaunch_M79"};
     magazines[] = {mag_5("1Rnd_HE_Grenade_shell")};
     respawnMagazines[] = {mag_5("1Rnd_HE_Grenade_shell")};
-	backpack = "TACU_Revolutionaries_Backpack_M79";
+    backpack = "TACU_Revolutionaries_Backpack_M79";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Tanoan_Rifleman07: TACU_Revolutionaries_U_O_Tanoan_Base {
     displayName = "Submachine Gunner (Bizon)"; 
     scope = 2;
@@ -117,10 +106,9 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman07: TACU_Revolutionaries_U_O_Tanoa
     respawnWeapons[] = {"CUP_smg_bizon"};
     magazines[] = {mag_2("CUP_64Rnd_9x19_Bizon_M")};
     respawnMagazines[] = {mag_2("CUP_64Rnd_9x19_Bizon_M")};
-	backpack = "TACU_Revolutionaries_Backpack_Bizon";
+    backpack = "TACU_Revolutionaries_Backpack_Bizon";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Tanoan_Rifleman08: TACU_Revolutionaries_U_O_Tanoan_Base {
     displayName = "Machine Gunner (UK-59)"; 
     scope = 2;
@@ -130,10 +118,9 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman08: TACU_Revolutionaries_U_O_Tanoa
     respawnWeapons[] = {"CUP_lmg_UK59"};
     magazines[] = {mag_2("CUP_50Rnd_UK59_762x54R_Tracer")};
     respawnMagazines[] = {mag_2("CUP_50Rnd_UK59_762x54R_Tracer")};
-	backpack = "TACU_Revolutionaries_Backpack_UK59";
+    backpack = "TACU_Revolutionaries_Backpack_UK59";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Tanoan_Rifleman09: TACU_Revolutionaries_U_O_Tanoan_Base {
     displayName = "Machine Gunner (FN Minimi SPW)"; 
     scope = 2;
@@ -143,10 +130,9 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman09: TACU_Revolutionaries_U_O_Tanoa
     respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_FNMinimiSPW"};
     magazines[] = {"200Rnd_556x45_Box_F"};
     respawnMagazines[] = {"200Rnd_556x45_Box_F"};
-	backpack = "TACU_Revolutionaries_Backpack_FNMinimiSPW";
+    backpack = "TACU_Revolutionaries_Backpack_FNMinimiSPW";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_O_Tanoan_Rifleman10: TACU_Revolutionaries_U_O_Tanoan_Base {
     displayName = "Rifleman (CZ805 A2)"; 
     scope = 2;
@@ -156,6 +142,6 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman10: TACU_Revolutionaries_U_O_Tanoa
     respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_CZ805A2"};
     magazines[] = {mag_2("CUP_30Rnd_556x45_G36")};
     respawnMagazines[] = {mag_2("CUP_30Rnd_556x45_G36")};
-	backpack = "TACU_Revolutionaries_Backpack_CZ805A2";
+    backpack = "TACU_Revolutionaries_Backpack_CZ805A2";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };

--- a/addons/revolutionaries/CfgVehicles_Tanoan.hpp
+++ b/addons/revolutionaries/CfgVehicles_Tanoan.hpp
@@ -1,0 +1,161 @@
+// Units - Revolutionaries (Tanoan)
+
+class TACU_Revolutionaries_U_O_Tanoan_Base: TACU_Main_U_OPFOR_Soldier_Base {
+    author = "Jack";
+    displayName = "Rifleman (FAL)";
+    faction = "TACU_Revolutionaries_O";
+    scope = 2;
+    scopeCurator = 2;
+    identityTypes[] = {"LanguageFRE_F", "Head_Tanoan", "G_Balaclava_blk"};
+    genericNames = "TanoanMen";
+    icon = "iconMan";
+    role = "Rifleman";
+    uniformClass = "U_C_MAN_casual_1_F";
+    backpack = "TACU_Revolutionaries_Backpack_FNFAL";
+    linkedItems[] = {"ItemWatch","ItemCompass","ItemMap"};
+    respawnLinkedItems[] = {"ItemWatch","ItemCompass","ItemMap"};
+    Items[] = {mag_5("ACE_fieldDressing"),"ACE_EarPlugs"};
+    respawnItems[] = {mag_5("ACE_fieldDressing"),"ACE_EarPlugs"};
+    weapons[] = {"CUP_arifle_FNFAL"};
+    respawnWeapons[] = {"CUP_arifle_FNFAL"};
+    magazines[] = {mag_2("CUP_20Rnd_762x51_FNFAL_M")};
+    respawnMagazines[] = {mag_2("CUP_20Rnd_762x51_FNFAL_M")};
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Tanoan";
+    // editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman.jpg);
+    headgearList[] = {};
+    TACU_allowedFacewear[] = {
+        "G_Balaclava_blk", 1
+    };
+};
+
+//Unit Specifics
+
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman01: TACU_Revolutionaries_U_O_Tanoan_Base {
+    displayName = "Rifleman (MK14)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_MAN_casual_2_F";
+    weapons[] = {"srifle_DMR_06_hunter_F"};
+    respawnWeapons[] = {"srifle_DMR_06_hunter_F"};
+    magazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
+    respawnMagazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
+	backpack = "TACU_Revolutionaries_Backpack_Mk14";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman02: TACU_Revolutionaries_U_O_Tanoan_Base {
+    displayName = "Shotgunner"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_MAN_casual_3_F";
+    weapons[] = {"sgun_HunterShotgun_01_F"};
+    respawnWeapons[] = {"sgun_HunterShotgun_01_F"};
+    magazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
+    respawnMagazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
+	backpack = "TACU_Revolutionaries_Backpack_Shotgun";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman03: TACU_Revolutionaries_U_O_Tanoan_Base {
+    displayName = "Submachine Gunner (MP5K)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_MAN_casual_4_F";
+    weapons[] = {"TACU_Revolutionaries_Weapon_O_MP5K"};
+    respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_MP5K"};
+    magazines[] = {mag_2("30Rnd_9x21_Mag_SMG_02")};
+    respawnMagazines[] = {mag_2("30Rnd_9x21_Mag_SMG_02")};
+	backpack = "TACU_Revolutionaries_Backpack_MP5K";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman04: TACU_Revolutionaries_U_O_Tanoan_Base {
+    displayName = "Marksmen"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_MAN_casual_5_F";
+    weapons[] = {"CUP_srifle_CZ550"};
+    respawnWeapons[] = {"CUP_srifle_CZ550"};
+    magazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
+    respawnMagazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
+	backpack = "TACU_Revolutionaries_Backpack_CZ550";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman05: TACU_Revolutionaries_U_O_Tanoan_Base {
+    displayName = "Rifleman (Lee Enfield)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_MAN_casual_6_F";
+    weapons[] = {"CUP_srifle_LeeEnfield"};
+    respawnWeapons[] = {"CUP_srifle_LeeEnfield"};
+    magazines[] = {mag_2("CUP_10x_303_M")};
+    respawnMagazines[] = {mag_2("CUP_10x_303_M")};
+	backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman06: TACU_Revolutionaries_U_O_Tanoan_Base {
+    displayName = "Grenadier"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_Poloshirt_blue";
+    weapons[] = {"CUP_glaunch_M79"};
+    respawnWeapons[] = {"CUP_glaunch_M79"};
+    magazines[] = {mag_5("1Rnd_HE_Grenade_shell")};
+    respawnMagazines[] = {mag_5("1Rnd_HE_Grenade_shell")};
+	backpack = "TACU_Revolutionaries_Backpack_M79";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman07: TACU_Revolutionaries_U_O_Tanoan_Base {
+    displayName = "Submachine Gunner (Bizon)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_Poloshirt_burgundy";
+    weapons[] = {"CUP_smg_bizon"};
+    respawnWeapons[] = {"CUP_smg_bizon"};
+    magazines[] = {mag_2("CUP_64Rnd_9x19_Bizon_M")};
+    respawnMagazines[] = {mag_2("CUP_64Rnd_9x19_Bizon_M")};
+	backpack = "TACU_Revolutionaries_Backpack_Bizon";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman08: TACU_Revolutionaries_U_O_Tanoan_Base {
+    displayName = "Machine Gunner (UK-59)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_Poloshirt_redwhite";
+    weapons[] = {"CUP_lmg_UK59"};
+    respawnWeapons[] = {"CUP_lmg_UK59"};
+    magazines[] = {mag_2("CUP_50Rnd_UK59_762x54R_Tracer")};
+    respawnMagazines[] = {mag_2("CUP_50Rnd_UK59_762x54R_Tracer")};
+	backpack = "TACU_Revolutionaries_Backpack_UK59";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman09: TACU_Revolutionaries_U_O_Tanoan_Base {
+    displayName = "Machine Gunner (FN Minimi SPW)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_Poloshirt_salmon";
+    weapons[] = {"TACU_Revolutionaries_Weapon_O_FNMinimiSPW"};
+    respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_FNMinimiSPW"};
+    magazines[] = {"200Rnd_556x45_Box_F"};
+    respawnMagazines[] = {"200Rnd_556x45_Box_F"};
+	backpack = "TACU_Revolutionaries_Backpack_FNMinimiSPW";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_O_Tanoan_Rifleman10: TACU_Revolutionaries_U_O_Tanoan_Base {
+    displayName = "Rifleman (CZ805 A2)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_Poloshirt_tricolour";
+    weapons[] = {"TACU_Revolutionaries_Weapon_O_CZ805A2"};
+    respawnWeapons[] = {"TACU_Revolutionaries_Weapon_O_CZ805A2"};
+    magazines[] = {mag_2("CUP_30Rnd_556x45_G36")};
+    respawnMagazines[] = {mag_2("CUP_30Rnd_556x45_G36")};
+	backpack = "TACU_Revolutionaries_Backpack_CZ805A2";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};

--- a/addons/revolutionaries/CfgVehicles_TanoanHD.hpp
+++ b/addons/revolutionaries/CfgVehicles_TanoanHD.hpp
@@ -1,0 +1,83 @@
+//Home Defense (Tanoan)
+
+class TACU_Revolutionaries_U_I_Tanoan_Base: TACU_Main_U_INDEP_Soldier_Base {
+    author = "Jack";
+    displayName = "Rifleman (FAL)";
+    faction = "TACU_Revolutionaries_I";
+    scope = 2;
+    scopeCurator = 2;
+    identityTypes[] = {"LanguageFRE_F", "Head_Tanoan", "G_Balaclava_blk"};
+    genericNames = "TanoanMen";
+    icon = "iconMan";
+    role = "Rifleman";
+    uniformClass = "U_C_MAN_casual_1_F";
+    backpack = "TACU_Revolutionaries_Backpack_FNFAL";
+    linkedItems[] = {"ItemWatch","ItemCompass","ItemMap"};
+    respawnLinkedItems[] = {"ItemWatch","ItemCompass","ItemMap"};
+    Items[] = {mag_5("ACE_fieldDressing"),"ACE_EarPlugs"};
+    respawnItems[] = {mag_5("ACE_fieldDressing"),"ACE_EarPlugs"};
+    weapons[] = {"CUP_arifle_FNFAL"};
+    respawnWeapons[] = {"CUP_arifle_FNFAL"};
+    magazines[] = {mag_2("CUP_20Rnd_762x51_FNFAL_M")};
+    respawnMagazines[] = {mag_2("CUP_20Rnd_762x51_FNFAL_M")};
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Tanoan";
+    // editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman.jpg);
+    headgearList[] = {};
+    TACU_allowedFacewear[] = {
+        "None", 1
+    };
+};
+
+//Unit Specifics
+
+class TACU_Revolutionaries_U_I_Tanoan_Rifleman01: TACU_Revolutionaries_U_I_Tanoan_Base {
+    displayName = "Rifleman (MK14)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_MAN_casual_2_F";
+    weapons[] = {"srifle_DMR_06_hunter_F"};
+    respawnWeapons[] = {"srifle_DMR_06_hunter_F"};
+    magazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
+    respawnMagazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
+	backpack = "TACU_Revolutionaries_Backpack_Mk14";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_I_Tanoan_Rifleman02: TACU_Revolutionaries_U_I_Tanoan_Base {
+    displayName = "Shotgunner"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_MAN_casual_3_F";
+    weapons[] = {"sgun_HunterShotgun_01_F"};
+    respawnWeapons[] = {"sgun_HunterShotgun_01_F"};
+    magazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
+    respawnMagazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
+	backpack = "TACU_Revolutionaries_Backpack_Shotgun";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_I_Tanoan_Rifleman03: TACU_Revolutionaries_U_I_Tanoan_Base {
+    displayName = "Marksmen"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_MAN_casual_5_F";
+    weapons[] = {"CUP_srifle_CZ550"};
+    respawnWeapons[] = {"CUP_srifle_CZ550"};
+    magazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
+    respawnMagazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
+	backpack = "TACU_Revolutionaries_Backpack_CZ550";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};
+
+class TACU_Revolutionaries_U_I_Tanoan_Rifleman04: TACU_Revolutionaries_U_I_Tanoan_Base {
+    displayName = "Rifleman (Lee Enfield)"; 
+    scope = 2;
+    scopeCurator = 2;
+    uniformClass = "U_C_MAN_casual_6_F";
+    weapons[] = {"CUP_srifle_LeeEnfield"};
+    respawnWeapons[] = {"CUP_srifle_LeeEnfield"};
+    magazines[] = {mag_2("CUP_10x_303_M")};
+    respawnMagazines[] = {mag_2("CUP_10x_303_M")};
+	backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
+    //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
+};

--- a/addons/revolutionaries/CfgVehicles_TanoanHD.hpp
+++ b/addons/revolutionaries/CfgVehicles_TanoanHD.hpp
@@ -1,6 +1,4 @@
-//Home Defense (Tanoan)
-
-class TACU_Revolutionaries_U_I_Tanoan_Base: TACU_Main_U_INDEP_Soldier_Base {
+class TACU_Revolutionaries_U_I_Tanoan_Base: TACU_Main_U_INDEP_Soldier_Base { //Home Defense (Tanoan)
     author = "Jack";
     displayName = "Rifleman (FAL)";
     faction = "TACU_Revolutionaries_I";
@@ -27,10 +25,7 @@ class TACU_Revolutionaries_U_I_Tanoan_Base: TACU_Main_U_INDEP_Soldier_Base {
         "None", 1
     };
 };
-
-//Unit Specifics
-
-class TACU_Revolutionaries_U_I_Tanoan_Rifleman01: TACU_Revolutionaries_U_I_Tanoan_Base {
+class TACU_Revolutionaries_U_I_Tanoan_Rifleman01: TACU_Revolutionaries_U_I_Tanoan_Base { //Unit Specifics
     displayName = "Rifleman (MK14)"; 
     scope = 2;
     scopeCurator = 2;
@@ -39,10 +34,9 @@ class TACU_Revolutionaries_U_I_Tanoan_Rifleman01: TACU_Revolutionaries_U_I_Tanoa
     respawnWeapons[] = {"srifle_DMR_06_hunter_F"};
     magazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
     respawnMagazines[] = {mag_2("10Rnd_Mk14_762x51_Mag")};
-	backpack = "TACU_Revolutionaries_Backpack_Mk14";
+    backpack = "TACU_Revolutionaries_Backpack_Mk14";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_I_Tanoan_Rifleman02: TACU_Revolutionaries_U_I_Tanoan_Base {
     displayName = "Shotgunner"; 
     scope = 2;
@@ -52,10 +46,9 @@ class TACU_Revolutionaries_U_I_Tanoan_Rifleman02: TACU_Revolutionaries_U_I_Tanoa
     respawnWeapons[] = {"sgun_HunterShotgun_01_F"};
     magazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
     respawnMagazines[] = {mag_4("2Rnd_12Gauge_Pellets")};
-	backpack = "TACU_Revolutionaries_Backpack_Shotgun";
+    backpack = "TACU_Revolutionaries_Backpack_Shotgun";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_I_Tanoan_Rifleman03: TACU_Revolutionaries_U_I_Tanoan_Base {
     displayName = "Marksmen"; 
     scope = 2;
@@ -65,10 +58,9 @@ class TACU_Revolutionaries_U_I_Tanoan_Rifleman03: TACU_Revolutionaries_U_I_Tanoa
     respawnWeapons[] = {"CUP_srifle_CZ550"};
     magazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
     respawnMagazines[] = {mag_2("CUP_5x_22_LR_17_HMR_M")};
-	backpack = "TACU_Revolutionaries_Backpack_CZ550";
+    backpack = "TACU_Revolutionaries_Backpack_CZ550";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
-
 class TACU_Revolutionaries_U_I_Tanoan_Rifleman04: TACU_Revolutionaries_U_I_Tanoan_Base {
     displayName = "Rifleman (Lee Enfield)"; 
     scope = 2;
@@ -78,6 +70,6 @@ class TACU_Revolutionaries_U_I_Tanoan_Rifleman04: TACU_Revolutionaries_U_I_Tanoa
     respawnWeapons[] = {"CUP_srifle_LeeEnfield"};
     magazines[] = {mag_2("CUP_10x_303_M")};
     respawnMagazines[] = {mag_2("CUP_10x_303_M")};
-	backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
+    backpack = "TACU_Revolutionaries_Backpack_LeeEnfield";
     //editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };

--- a/addons/revolutionaries/CfgVehicles_Vehicles.hpp
+++ b/addons/revolutionaries/CfgVehicles_Vehicles.hpp
@@ -2,7 +2,7 @@ class C_Hatchback_01_F; //Revolutionaries (Tanoan)
 class TACU_Revolutionaries_V_O_Hatchback01: C_Hatchback_01_F { 
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
     side = 0;
     displayName = "Hatchback";
     crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
@@ -12,7 +12,7 @@ class C_Truck_02_transport_F;
 class TACU_Revolutionaries_V_O_Transport01: C_Truck_02_transport_F {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
     side = 0;
     displayName = "KamAZ Transport";
     crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
@@ -22,7 +22,7 @@ class C_Offroad_01_covered_F;
 class TACU_Revolutionaries_V_O_OffroadC01: C_Offroad_01_covered_F {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
     side = 0;
     displayName = "Offroad";
     crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
@@ -32,7 +32,7 @@ class I_C_Offroad_02_LMG_F;
 class TACU_Revolutionaries_V_O_Jeep_LMG: I_C_Offroad_02_LMG_F {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
     side = 0;
     displayName = "Jeep (LMG)";
     crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
@@ -43,7 +43,7 @@ class CUP_C_Datsun_4seat; //Revolutionaries (Russian)
 class TACU_Revolutionaries_V_O_Datsun_5Seat: CUP_C_Datsun_4seat {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
     side = 0;
     displayName = "Datsun (5 Seats)";
     crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
@@ -53,7 +53,7 @@ class CUP_C_Golf4_black_Civ;
 class TACU_Revolutionaries_V_O_Golf_Black: CUP_C_Golf4_black_Civ {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
     side = 0;
     displayName = "Golf (Black)";
     crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
@@ -63,7 +63,7 @@ class CUP_C_Skoda_Blue_CIV;
 class TACU_Revolutionaries_V_O_Skoda_Blue: CUP_C_Skoda_Blue_CIV {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
     side = 0;
     displayName = "Skoda (Blue)";
     crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
@@ -73,18 +73,18 @@ class CUP_O_Datsun_PK;
 class TACU_Revolutionaries_V_O_Fatsun_PK: CUP_O_Datsun_PK {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
     side = 0;
     displayName = "Fatsun (PK)";
     crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
-	typicalCargo[] = {"TACU_Revolutionaries_U_O_Russian_Rifleman03"}
+    typicalCargo[] = {"TACU_Revolutionaries_U_O_Russian_Rifleman03"}
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
 class CUP_C_Ural_Civ_03;
 class TACU_Revolutionaries_V_O_Ural01: CUP_C_Ural_Civ_03 {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
     side = 0;
     displayName = "Ural (Worker)";
     crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
@@ -93,7 +93,7 @@ class TACU_Revolutionaries_V_O_Ural01: CUP_C_Ural_Civ_03 {
 class TACU_Revolutionaries_V_I_Datsun_5Seat: CUP_C_Datsun_4seat { //Home Defense (Russian)
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_I";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Russian";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Russian";
     side = 2;
     displayName = "Datsun (5 Seats)";
     crew = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
@@ -102,7 +102,7 @@ class TACU_Revolutionaries_V_I_Datsun_5Seat: CUP_C_Datsun_4seat { //Home Defense
 class TACU_Revolutionaries_V_I_Golf_Black: CUP_C_Golf4_black_Civ {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_I";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Russian";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Russian";
     side = 2;
     displayName = "Golf (Black)";
     crew = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
@@ -111,7 +111,7 @@ class TACU_Revolutionaries_V_I_Golf_Black: CUP_C_Golf4_black_Civ {
 class TACU_Revolutionaries_V_I_Skoda_Blue: CUP_C_Skoda_Blue_CIV {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_I";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Russian";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Russian";
     side = 2;
     displayName = "Skoda (Blue)";
     crew = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
@@ -121,7 +121,7 @@ class C_Offroad_01_F; //Home Defense (Tanoan)
 class TACU_Revolutionaries_V_I_OffroadC01: C_Offroad_01_F {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_I";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Tanoa";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Tanoa";
     side = 2;
     displayName = "Offroad";
     crew = "TACU_Revolutionaries_U_I_Tanoan_Rifleman04";
@@ -130,7 +130,7 @@ class TACU_Revolutionaries_V_I_OffroadC01: C_Offroad_01_F {
 class TACU_Revolutionaries_V_I_Hatchback01: C_Hatchback_01_F {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_I";
-	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Tanoa";
+    editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Tanoa";
     side = 2;
     displayName = "Hatchback";
     crew = "TACU_Revolutionaries_U_I_Tanoan_Rifleman04";

--- a/addons/revolutionaries/CfgVehicles_Vehicles.hpp
+++ b/addons/revolutionaries/CfgVehicles_Vehicles.hpp
@@ -1,6 +1,5 @@
-//Revolutionaries (Tanoan)
-class C_Hatchback_01_F;
-class TACU_Revolutionaries_V_O_Hatchback01: C_Hatchback_01_F {
+class C_Hatchback_01_F; //Revolutionaries (Tanoan)
+class TACU_Revolutionaries_V_O_Hatchback01: C_Hatchback_01_F { 
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
 	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
@@ -9,7 +8,6 @@ class TACU_Revolutionaries_V_O_Hatchback01: C_Hatchback_01_F {
     crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
 class C_Truck_02_transport_F;
 class TACU_Revolutionaries_V_O_Transport01: C_Truck_02_transport_F {
     MACRO_CLEAR_VEHICLE_CARGO
@@ -20,7 +18,6 @@ class TACU_Revolutionaries_V_O_Transport01: C_Truck_02_transport_F {
     crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
 class C_Offroad_01_covered_F;
 class TACU_Revolutionaries_V_O_OffroadC01: C_Offroad_01_covered_F {
     MACRO_CLEAR_VEHICLE_CARGO
@@ -31,7 +28,6 @@ class TACU_Revolutionaries_V_O_OffroadC01: C_Offroad_01_covered_F {
     crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
 class I_C_Offroad_02_LMG_F;
 class TACU_Revolutionaries_V_O_Jeep_LMG: I_C_Offroad_02_LMG_F {
     MACRO_CLEAR_VEHICLE_CARGO
@@ -43,9 +39,7 @@ class TACU_Revolutionaries_V_O_Jeep_LMG: I_C_Offroad_02_LMG_F {
     typicalCargo[] = {"TACU_Revolutionaries_U_O_Tanoan_Rifleman03"};
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
-//Revolutionaries (Russian)
-class CUP_C_Datsun_4seat;
+class CUP_C_Datsun_4seat; //Revolutionaries (Russian)
 class TACU_Revolutionaries_V_O_Datsun_5Seat: CUP_C_Datsun_4seat {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_O";
@@ -55,7 +49,6 @@ class TACU_Revolutionaries_V_O_Datsun_5Seat: CUP_C_Datsun_4seat {
     crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
 class CUP_C_Golf4_black_Civ;
 class TACU_Revolutionaries_V_O_Golf_Black: CUP_C_Golf4_black_Civ {
     MACRO_CLEAR_VEHICLE_CARGO
@@ -66,7 +59,6 @@ class TACU_Revolutionaries_V_O_Golf_Black: CUP_C_Golf4_black_Civ {
     crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
 class CUP_C_Skoda_Blue_CIV;
 class TACU_Revolutionaries_V_O_Skoda_Blue: CUP_C_Skoda_Blue_CIV {
     MACRO_CLEAR_VEHICLE_CARGO
@@ -77,7 +69,6 @@ class TACU_Revolutionaries_V_O_Skoda_Blue: CUP_C_Skoda_Blue_CIV {
     crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
 class CUP_O_Datsun_PK;
 class TACU_Revolutionaries_V_O_Fatsun_PK: CUP_O_Datsun_PK {
     MACRO_CLEAR_VEHICLE_CARGO
@@ -89,7 +80,6 @@ class TACU_Revolutionaries_V_O_Fatsun_PK: CUP_O_Datsun_PK {
 	typicalCargo[] = {"TACU_Revolutionaries_U_O_Russian_Rifleman03"}
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
 class CUP_C_Ural_Civ_03;
 class TACU_Revolutionaries_V_O_Ural01: CUP_C_Ural_Civ_03 {
     MACRO_CLEAR_VEHICLE_CARGO
@@ -100,9 +90,7 @@ class TACU_Revolutionaries_V_O_Ural01: CUP_C_Ural_Civ_03 {
     crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
-//Home Defense (Russian)
-class TACU_Revolutionaries_V_I_Datsun_5Seat: CUP_C_Datsun_4seat {
+class TACU_Revolutionaries_V_I_Datsun_5Seat: CUP_C_Datsun_4seat { //Home Defense (Russian)
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_I";
 	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Russian";
@@ -111,7 +99,6 @@ class TACU_Revolutionaries_V_I_Datsun_5Seat: CUP_C_Datsun_4seat {
     crew = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
 class TACU_Revolutionaries_V_I_Golf_Black: CUP_C_Golf4_black_Civ {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_I";
@@ -121,7 +108,6 @@ class TACU_Revolutionaries_V_I_Golf_Black: CUP_C_Golf4_black_Civ {
     crew = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
 class TACU_Revolutionaries_V_I_Skoda_Blue: CUP_C_Skoda_Blue_CIV {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_I";
@@ -131,9 +117,7 @@ class TACU_Revolutionaries_V_I_Skoda_Blue: CUP_C_Skoda_Blue_CIV {
     crew = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
-//Home Defense (Tanoan)
-class C_Offroad_01_F;
+class C_Offroad_01_F; //Home Defense (Tanoan)
 class TACU_Revolutionaries_V_I_OffroadC01: C_Offroad_01_F {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_I";
@@ -143,7 +127,6 @@ class TACU_Revolutionaries_V_I_OffroadC01: C_Offroad_01_F {
     crew = "TACU_Revolutionaries_U_I_Tanoan_Rifleman04";
     //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
 };
-
 class TACU_Revolutionaries_V_I_Hatchback01: C_Hatchback_01_F {
     MACRO_CLEAR_VEHICLE_CARGO
     faction = "TACU_Revolutionaries_I";

--- a/addons/revolutionaries/CfgVehicles_Vehicles.hpp
+++ b/addons/revolutionaries/CfgVehicles_Vehicles.hpp
@@ -1,0 +1,155 @@
+//Revolutionaries (Tanoan)
+class C_Hatchback_01_F;
+class TACU_Revolutionaries_V_O_Hatchback01: C_Hatchback_01_F {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_O";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
+    side = 0;
+    displayName = "Hatchback";
+    crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+class C_Truck_02_transport_F;
+class TACU_Revolutionaries_V_O_Transport01: C_Truck_02_transport_F {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_O";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
+    side = 0;
+    displayName = "KamAZ Transport";
+    crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+class C_Offroad_01_covered_F;
+class TACU_Revolutionaries_V_O_OffroadC01: C_Offroad_01_covered_F {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_O";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
+    side = 0;
+    displayName = "Offroad";
+    crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+class I_C_Offroad_02_LMG_F;
+class TACU_Revolutionaries_V_O_Jeep_LMG: I_C_Offroad_02_LMG_F {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_O";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Tanoa";
+    side = 0;
+    displayName = "Jeep (LMG)";
+    crew = "TACU_Revolutionaries_U_O_Tanoan_Rifleman05";
+    typicalCargo[] = {"TACU_Revolutionaries_U_O_Tanoan_Rifleman03"};
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+//Revolutionaries (Russian)
+class CUP_C_Datsun_4seat;
+class TACU_Revolutionaries_V_O_Datsun_5Seat: CUP_C_Datsun_4seat {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_O";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
+    side = 0;
+    displayName = "Datsun (5 Seats)";
+    crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+class CUP_C_Golf4_black_Civ;
+class TACU_Revolutionaries_V_O_Golf_Black: CUP_C_Golf4_black_Civ {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_O";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
+    side = 0;
+    displayName = "Golf (Black)";
+    crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+class CUP_C_Skoda_Blue_CIV;
+class TACU_Revolutionaries_V_O_Skoda_Blue: CUP_C_Skoda_Blue_CIV {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_O";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
+    side = 0;
+    displayName = "Skoda (Blue)";
+    crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+class CUP_O_Datsun_PK;
+class TACU_Revolutionaries_V_O_Fatsun_PK: CUP_O_Datsun_PK {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_O";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
+    side = 0;
+    displayName = "Fatsun (PK)";
+    crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
+	typicalCargo[] = {"TACU_Revolutionaries_U_O_Russian_Rifleman03"}
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+class CUP_C_Ural_Civ_03;
+class TACU_Revolutionaries_V_O_Ural01: CUP_C_Ural_Civ_03 {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_O";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_O_Cars_Russian";
+    side = 0;
+    displayName = "Ural (Worker)";
+    crew = "TACU_Revolutionaries_U_O_Russian_Rifleman05";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+//Home Defense (Russian)
+class TACU_Revolutionaries_V_I_Datsun_5Seat: CUP_C_Datsun_4seat {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_I";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Russian";
+    side = 2;
+    displayName = "Datsun (5 Seats)";
+    crew = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+class TACU_Revolutionaries_V_I_Golf_Black: CUP_C_Golf4_black_Civ {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_I";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Russian";
+    side = 2;
+    displayName = "Golf (Black)";
+    crew = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+class TACU_Revolutionaries_V_I_Skoda_Blue: CUP_C_Skoda_Blue_CIV {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_I";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Russian";
+    side = 2;
+    displayName = "Skoda (Blue)";
+    crew = "TACU_Revolutionaries_U_I_Russian_Rifleman04";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+//Home Defense (Tanoan)
+class C_Offroad_01_F;
+class TACU_Revolutionaries_V_I_OffroadC01: C_Offroad_01_F {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_I";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Tanoa";
+    side = 2;
+    displayName = "Offroad";
+    crew = "TACU_Revolutionaries_U_I_Tanoan_Rifleman04";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};
+
+class TACU_Revolutionaries_V_I_Hatchback01: C_Hatchback_01_F {
+    MACRO_CLEAR_VEHICLE_CARGO
+    faction = "TACU_Revolutionaries_I";
+	editorSubcategory = "TACU_Revolutionaries_EdSubCat_I_Cars_Tanoa";
+    side = 2;
+    displayName = "Hatchback";
+    crew = "TACU_Revolutionaries_U_I_Tanoan_Rifleman04";
+    //editorPreview = QPATHTOF(ui\Cartel_V_O_Offroad_Jeep.jpg);
+};

--- a/addons/revolutionaries/CfgWeapons.hpp
+++ b/addons/revolutionaries/CfgWeapons.hpp
@@ -1,0 +1,33 @@
+class CfgWeapons {
+
+    // Weapons
+    class SMG_05_F;
+    class TACU_Revolutionaries_Weapon_O_MP5K: SMG_05_F {
+        dlc = QUOTE(PREFIX);
+        scope = 1;
+        scopeCurator = 1;
+        class LinkedItems {
+            EQUIP_POINTER(acc_flashlight);
+        };
+    };
+
+class LMG_03_F;
+ class TACU_Revolutionaries_Weapon_O_FNMinimiSPW: LMG_03_F {
+        dlc = QUOTE(PREFIX);
+        scope = 1;
+        scopeCurator = 1;
+        class LinkedItems {
+            EQUIP_POINTER(acc_flashlight);
+        };
+    };
+
+class CUP_arifle_CZ805_A2;
+class TACU_Revolutionaries_Weapon_O_CZ805A2: CUP_arifle_CZ805_A2{
+	 dlc = QUOTE(PREFIX);
+        scope = 1;
+        scopeCurator = 1;
+        class LinkedItems {
+            EQUIP_POINTER(acc_flashlight);
+        };
+};
+};

--- a/addons/revolutionaries/CfgWeapons.hpp
+++ b/addons/revolutionaries/CfgWeapons.hpp
@@ -1,6 +1,4 @@
 class CfgWeapons {
-
-    // Weapons
     class SMG_05_F;
     class TACU_Revolutionaries_Weapon_O_MP5K: SMG_05_F {
         dlc = QUOTE(PREFIX);
@@ -10,9 +8,8 @@ class CfgWeapons {
             EQUIP_POINTER(acc_flashlight);
         };
     };
-
-class LMG_03_F;
- class TACU_Revolutionaries_Weapon_O_FNMinimiSPW: LMG_03_F {
+    class LMG_03_F;
+    class TACU_Revolutionaries_Weapon_O_FNMinimiSPW: LMG_03_F {
         dlc = QUOTE(PREFIX);
         scope = 1;
         scopeCurator = 1;
@@ -20,14 +17,13 @@ class LMG_03_F;
             EQUIP_POINTER(acc_flashlight);
         };
     };
-
-class CUP_arifle_CZ805_A2;
-class TACU_Revolutionaries_Weapon_O_CZ805A2: CUP_arifle_CZ805_A2{
-	 dlc = QUOTE(PREFIX);
+    class CUP_arifle_CZ805_A2;
+    class TACU_Revolutionaries_Weapon_O_CZ805A2: CUP_arifle_CZ805_A2 {
+	    dlc = QUOTE(PREFIX);
         scope = 1;
         scopeCurator = 1;
         class LinkedItems {
             EQUIP_POINTER(acc_flashlight);
         };
-};
+    };
 };

--- a/addons/revolutionaries/config.cpp
+++ b/addons/revolutionaries/config.cpp
@@ -1,81 +1,69 @@
 #include "script_component.hpp"
-
 class CfgPatches {
     class ADDON {
         name = COMPONENT_NAME;
         units[] = {
-			//Backpacks
-			"TACU_Revolutionaries_Backpack_Mk14",
-			"TACU_Revolutionaries_Backpack_Shotgun",
-			"TACU_Revolutionaries_Backpack_MP5K",
-			"TACU_Revolutionaries_Backpack_CZ550",
-			"TACU_Revolutionaries_Backpack_LeeEnfield",
-			"TACU_Revolutionaries_Backpack_M79",
-			"TACU_Revolutionaries_Backpack_Bizon",
-			"TACU_Revolutionaries_Backpack_UK59",
-			"TACU_Revolutionaries_Backpack_FNMinimiSPW",
-			"TACU_Revolutionaries_Backpack_CZ805A2",
-			//Units
-			//Revolutionaries (Tanoan)
-            "TACU_Main_U_OPFOR_Soldier_Base",
-            "TACU_Revolutionaries_U_O_Tanoan_Base",
+            "TACU_Revolutionaries_Backpack_Mk14", //Backpacks
+            "TACU_Revolutionaries_Backpack_Shotgun",
+            "TACU_Revolutionaries_Backpack_MP5K",
+            "TACU_Revolutionaries_Backpack_CZ550",
+            "TACU_Revolutionaries_Backpack_LeeEnfield",
+            "TACU_Revolutionaries_Backpack_M79",
+            "TACU_Revolutionaries_Backpack_Bizon",
+            "TACU_Revolutionaries_Backpack_UK59",
+            "TACU_Revolutionaries_Backpack_FNMinimiSPW",
+            "TACU_Revolutionaries_Backpack_CZ805A2",
+            "TACU_Revolutionaries_U_O_Tanoan_Base", //Units - Revolutionaries (Tanoan)
             "TACU_Revolutionaries_U_O_Tanoan_Rifleman01",
-			"TACU_Revolutionaries_U_O_Tanoan_Rifleman02",
-			"TACU_Revolutionaries_U_O_Tanoan_Rifleman03",
-			"TACU_Revolutionaries_U_O_Tanoan_Rifleman04",
-			"TACU_Revolutionaries_U_O_Tanoan_Rifleman05",
-			"TACU_Revolutionaries_U_O_Tanoan_Rifleman06",
-			"TACU_Revolutionaries_U_O_Tanoan_Rifleman07",
-			"TACU_Revolutionaries_U_O_Tanoan_Rifleman08",
-			"TACU_Revolutionaries_U_O_Tanoan_Rifleman09",
-			"TACU_Revolutionaries_U_O_Tanoan_Rifleman10",
-			//Revolutionaries (Russian)
-			"TACU_Revolutionaries_U_O_Russian_Base",
+            "TACU_Revolutionaries_U_O_Tanoan_Rifleman02",
+            "TACU_Revolutionaries_U_O_Tanoan_Rifleman03",
+            "TACU_Revolutionaries_U_O_Tanoan_Rifleman04",
+            "TACU_Revolutionaries_U_O_Tanoan_Rifleman05",
+            "TACU_Revolutionaries_U_O_Tanoan_Rifleman06",
+            "TACU_Revolutionaries_U_O_Tanoan_Rifleman07",
+            "TACU_Revolutionaries_U_O_Tanoan_Rifleman08",
+            "TACU_Revolutionaries_U_O_Tanoan_Rifleman09",
+            "TACU_Revolutionaries_U_O_Tanoan_Rifleman10",		
+            "TACU_Revolutionaries_U_O_Russian_Base", //Units - Revolutionaries (Russian)
             "TACU_Revolutionaries_U_O_Russian_Rifleman01",
-			"TACU_Revolutionaries_U_O_Russian_Rifleman02",
-			"TACU_Revolutionaries_U_O_Russian_Rifleman03",
-			"TACU_Revolutionaries_U_O_Russian_Rifleman04",
-			"TACU_Revolutionaries_U_O_Russian_Rifleman05",
-			"TACU_Revolutionaries_U_O_Russian_Rifleman06",
-			"TACU_Revolutionaries_U_O_Russian_Rifleman07",
-			"TACU_Revolutionaries_U_O_Russian_Rifleman08",
-			"TACU_Revolutionaries_U_O_Russian_Rifleman09",
-			"TACU_Revolutionaries_U_O_Russian_Rifleman10",
-			//Civil Defense
-			"TACU_Main_U_INDEP_Soldier_Base",
-			"TACU_Revolutionaries_U_I_Tanoan_Base",
+            "TACU_Revolutionaries_U_O_Russian_Rifleman02",
+            "TACU_Revolutionaries_U_O_Russian_Rifleman03",
+            "TACU_Revolutionaries_U_O_Russian_Rifleman04",
+            "TACU_Revolutionaries_U_O_Russian_Rifleman05",
+            "TACU_Revolutionaries_U_O_Russian_Rifleman06",
+            "TACU_Revolutionaries_U_O_Russian_Rifleman07",
+            "TACU_Revolutionaries_U_O_Russian_Rifleman08",
+            "TACU_Revolutionaries_U_O_Russian_Rifleman09",
+            "TACU_Revolutionaries_U_O_Russian_Rifleman10",			
+            "TACU_Revolutionaries_U_I_Tanoan_Base", //Units - Civil Defense (Tanoan)
             "TACU_Revolutionaries_U_I_Tanoan_Rifleman01",
-			"TACU_Revolutionaries_U_I_Tanoan_Rifleman02",
-			"TACU_Revolutionaries_U_I_Tanoan_Rifleman03",
-			"TACU_Revolutionaries_U_I_Tanoan_Rifleman04",
-			"TACU_Revolutionaries_U_I_Russian_Base",
+            "TACU_Revolutionaries_U_I_Tanoan_Rifleman02",
+            "TACU_Revolutionaries_U_I_Tanoan_Rifleman03",
+            "TACU_Revolutionaries_U_I_Tanoan_Rifleman04",
+            "TACU_Revolutionaries_U_I_Russian_Base", //Units - Civil Defense (Russian)
             "TACU_Revolutionaries_U_I_Russian_Rifleman01",
-			"TACU_Revolutionaries_U_I_Russian_Rifleman02",
-			"TACU_Revolutionaries_U_I_Russian_Rifleman03",
-			"TACU_Revolutionaries_U_I_Russian_Rifleman04",
-			//Vics
-			//Tanoan
-		"TACU_Revolutionaries_V_O_Hatchback01",
-		"TACU_Revolutionaries_V_O_Transport01",
-		"TACU_Revolutionaries_V_O_OffroadC01",
-		"TACU_Revolutionaries_V_O_Jeep_LMG",
-			//Russian
-		"TACU_Revolutionaries_V_O_Datsun_5Seat",
-		"TACU_Revolutionaries_V_O_Golf_Black",
-		"TACU_Revolutionaries_V_O_Skoda_Blue",
-		"TACU_Revolutionaries_V_O_Fatsun_PK",
-		"TACU_Revolutionaries_V_O_Ural01",
-		//Civil Defense
-		"TACU_Revolutionaries_V_I_Hatchback01",
-		"TACU_Revolutionaries_V_I_OffroadC01",
-		"TACU_Revolutionaries_V_I_Datsun_5Seat",
-		"TACU_Revolutionaries_V_I_Golf_Black",
-		"TACU_Revolutionaries_V_I_Skoda_Blue"
-                };
+            "TACU_Revolutionaries_U_I_Russian_Rifleman02",
+            "TACU_Revolutionaries_U_I_Russian_Rifleman03",
+            "TACU_Revolutionaries_U_I_Russian_Rifleman04",		
+            "TACU_Revolutionaries_V_O_Hatchback01", //Vehicles - Revolutionaries (Tanoan)
+            "TACU_Revolutionaries_V_O_Transport01",
+            "TACU_Revolutionaries_V_O_OffroadC01",
+            "TACU_Revolutionaries_V_O_Jeep_LMG",		
+            "TACU_Revolutionaries_V_O_Datsun_5Seat", //Vehicles - Revolutionaries (Russian)
+            "TACU_Revolutionaries_V_O_Golf_Black",
+            "TACU_Revolutionaries_V_O_Skoda_Blue",
+            "TACU_Revolutionaries_V_O_Fatsun_PK",
+            "TACU_Revolutionaries_V_O_Ural01",
+            "TACU_Revolutionaries_V_I_Hatchback01", //Vehicles - Civil Defense
+            "TACU_Revolutionaries_V_I_OffroadC01",
+            "TACU_Revolutionaries_V_I_Datsun_5Seat",
+            "TACU_Revolutionaries_V_I_Golf_Black",
+            "TACU_Revolutionaries_V_I_Skoda_Blue"
+        };
         weapons[] = {
-		"TACU_Revolutionaries_Weapon_O_MP5K",
-		"TACU_Revolutionaries_Weapon_O_FNMinimiSPW",	
-		"TACU_Revolutionaries_Weapon_O_CZ805A2"
+            "TACU_Revolutionaries_Weapon_O_MP5K",
+            "TACU_Revolutionaries_Weapon_O_FNMinimiSPW",	
+            "TACU_Revolutionaries_Weapon_O_CZ805A2"
 		};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacu_main"};
@@ -84,11 +72,7 @@ class CfgPatches {
         VERSION_CONFIG;
     };
 };
-
 #include "CfgFactionClasses.hpp"
 #include "CfgGroups.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
-
-
-

--- a/addons/revolutionaries/config.cpp
+++ b/addons/revolutionaries/config.cpp
@@ -1,0 +1,94 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {
+			//Backpacks
+			"TACU_Revolutionaries_Backpack_Mk14",
+			"TACU_Revolutionaries_Backpack_Shotgun",
+			"TACU_Revolutionaries_Backpack_MP5K",
+			"TACU_Revolutionaries_Backpack_CZ550",
+			"TACU_Revolutionaries_Backpack_LeeEnfield",
+			"TACU_Revolutionaries_Backpack_M79",
+			"TACU_Revolutionaries_Backpack_Bizon",
+			"TACU_Revolutionaries_Backpack_UK59",
+			"TACU_Revolutionaries_Backpack_FNMinimiSPW",
+			"TACU_Revolutionaries_Backpack_CZ805A2",
+			//Units
+			//Revolutionaries (Tanoan)
+            "TACU_Main_U_OPFOR_Soldier_Base",
+            "TACU_Revolutionaries_U_O_Tanoan_Base",
+            "TACU_Revolutionaries_U_O_Tanoan_Rifleman01",
+			"TACU_Revolutionaries_U_O_Tanoan_Rifleman02",
+			"TACU_Revolutionaries_U_O_Tanoan_Rifleman03",
+			"TACU_Revolutionaries_U_O_Tanoan_Rifleman04",
+			"TACU_Revolutionaries_U_O_Tanoan_Rifleman05",
+			"TACU_Revolutionaries_U_O_Tanoan_Rifleman06",
+			"TACU_Revolutionaries_U_O_Tanoan_Rifleman07",
+			"TACU_Revolutionaries_U_O_Tanoan_Rifleman08",
+			"TACU_Revolutionaries_U_O_Tanoan_Rifleman09",
+			"TACU_Revolutionaries_U_O_Tanoan_Rifleman10",
+			//Revolutionaries (Russian)
+			"TACU_Revolutionaries_U_O_Russian_Base",
+            "TACU_Revolutionaries_U_O_Russian_Rifleman01",
+			"TACU_Revolutionaries_U_O_Russian_Rifleman02",
+			"TACU_Revolutionaries_U_O_Russian_Rifleman03",
+			"TACU_Revolutionaries_U_O_Russian_Rifleman04",
+			"TACU_Revolutionaries_U_O_Russian_Rifleman05",
+			"TACU_Revolutionaries_U_O_Russian_Rifleman06",
+			"TACU_Revolutionaries_U_O_Russian_Rifleman07",
+			"TACU_Revolutionaries_U_O_Russian_Rifleman08",
+			"TACU_Revolutionaries_U_O_Russian_Rifleman09",
+			"TACU_Revolutionaries_U_O_Russian_Rifleman10",
+			//Civil Defense
+			"TACU_Main_U_INDEP_Soldier_Base",
+			"TACU_Revolutionaries_U_I_Tanoan_Base",
+            "TACU_Revolutionaries_U_I_Tanoan_Rifleman01",
+			"TACU_Revolutionaries_U_I_Tanoan_Rifleman02",
+			"TACU_Revolutionaries_U_I_Tanoan_Rifleman03",
+			"TACU_Revolutionaries_U_I_Tanoan_Rifleman04",
+			"TACU_Revolutionaries_U_I_Russian_Base",
+            "TACU_Revolutionaries_U_I_Russian_Rifleman01",
+			"TACU_Revolutionaries_U_I_Russian_Rifleman02",
+			"TACU_Revolutionaries_U_I_Russian_Rifleman03",
+			"TACU_Revolutionaries_U_I_Russian_Rifleman04",
+			//Vics
+			//Tanoan
+		"TACU_Revolutionaries_V_O_Hatchback01",
+		"TACU_Revolutionaries_V_O_Transport01",
+		"TACU_Revolutionaries_V_O_OffroadC01",
+		"TACU_Revolutionaries_V_O_Jeep_LMG",
+			//Russian
+		"TACU_Revolutionaries_V_O_Datsun_5Seat",
+		"TACU_Revolutionaries_V_O_Golf_Black",
+		"TACU_Revolutionaries_V_O_Skoda_Blue",
+		"TACU_Revolutionaries_V_O_Fatsun_PK",
+		"TACU_Revolutionaries_V_O_Ural01",
+		//Civil Defense
+		"TACU_Revolutionaries_V_I_Hatchback01",
+		"TACU_Revolutionaries_V_I_OffroadC01",
+		"TACU_Revolutionaries_V_I_Datsun_5Seat",
+		"TACU_Revolutionaries_V_I_Golf_Black",
+		"TACU_Revolutionaries_V_I_Skoda_Blue"
+                };
+        weapons[] = {
+		"TACU_Revolutionaries_Weapon_O_MP5K",
+		"TACU_Revolutionaries_Weapon_O_FNMinimiSPW",	
+		"TACU_Revolutionaries_Weapon_O_CZ805A2"
+		};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tacu_main"};
+        author = ECSTRING(main,Author);
+        authors[] = {"Jack"};
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgFactionClasses.hpp"
+#include "CfgGroups.hpp"
+#include "CfgVehicles.hpp"
+#include "CfgWeapons.hpp"
+
+
+

--- a/addons/revolutionaries/script_component.hpp
+++ b/addons/revolutionaries/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT revolutionaries
+#define COMPONENT_BEAUTIFIED revolutionaries
+#include "\x\tacu\addons\main\script_mod.hpp"
+#include "\x\tacu\addons\main\script_macros.hpp"


### PR DESCRIPTION
This Faction has the core concept of being Civilians who have armed themselves to either revolt against their oppressors (Revolutionaries - OPFOR) or defend themselves (Civil Defence - INDEPENDENT) in addition AK use is avoided as many other Factions cover the use of these rifles.

The Revolutionaries all wear balaclavas and have greater firepower over their Civil Defence counterpart as they have been supplied additional arms from an Unknown source who will benefit from their actions.

This Faction is intended to not only be used alone but as supporting units to other factions as expendable. This will also increase intensity when other civilians are present in the AO as players will need to check their fire and use of Civilian vehicles will mean players will be unable to open fire on incoming vehicles before checking if units inside are hostile. 
