### PR TITLE
Update MSF AT Units

### DIFF
--- a/addons/msf/CfgVehicles.hpp
+++ b/addons/msf/CfgVehicles.hpp
@@ -1299,33 +1299,33 @@ class CfgVehicles {
         hiddenSelectionsMaterials[] = {QPATHTOF(data\poncho\MSF_B_Poncho_dry.rvmat)};
     };
 
-    class tacs_Backpack_Kitbag_DarkBlack;
-    class TACU_MSF_B_AT_Black: tacs_Backpack_Kitbag_DarkBlack {
+    class B_ViperLightHarness_blk_F;
+    class TACU_MSF_B_AT_Black: B_ViperLightHarness_blk_F {
         dlc = QUOTE(PREFIX);
         scope = 1;
         scopeCurator = 1;
         class TransportMagazines {
-            MACRO_ADDMAGAZINE(CUP_SMAW_HEDP_M,3);
+            MACRO_ADDMAGAZINE(MRAWS_HEAT_F,4);
         };
     };
 
-    class B_Kitbag_cbr;
-    class TACU_MSF_B_AT_Coyote: B_Kitbag_cbr {
+    class tacs_Backpack_ViperLightHarness_Coyote;
+    class TACU_MSF_B_AT_Coyote: tacs_Backpack_ViperLightHarness_Coyote {
         dlc = QUOTE(PREFIX);
         scope = 1;
         scopeCurator = 1;
         class TransportMagazines {
-            MACRO_ADDMAGAZINE(CUP_SMAW_HEDP_M,3);
+            MACRO_ADDMAGAZINE(MRAWS_HEAT_F,4);
         };
     };
 
-    class B_Kitbag_rgr;
-    class TACU_MSF_B_AT_Green: B_Kitbag_rgr {
+    class tacs_Backpack_ViperLightHarness_Green;
+    class TACU_MSF_B_AT_Green: tacs_Backpack_ViperLightHarness_Green {
         dlc = QUOTE(PREFIX);
         scope = 1;
         scopeCurator = 1;
         class TransportMagazines {
-            MACRO_ADDMAGAZINE(CUP_SMAW_HEDP_M,3);
+            MACRO_ADDMAGAZINE(MRAWS_HEAT_F,4);
         };
     };
 

--- a/addons/msf/CfgVehicles_DDogs_Black.hpp
+++ b/addons/msf/CfgVehicles_DDogs_Black.hpp
@@ -16,8 +16,8 @@ class TACU_MSF_U_I_DDogs_Black_Rifleman_01: TACU_Main_U_INDEP_Soldier_Base {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerBlack";
     backpack = "";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Black_Rifleman_01.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "tacs_Helmet_Enc_Ballistic_DarkBlack", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Black", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "tacs_Helmet_Enc_Ballistic_DarkBlack", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Black", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "tacs_Helmet_Enc_Ballistic_DarkBlack", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Black", "NVGoggles_OPFOR"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "tacs_Helmet_Enc_Ballistic_DarkBlack", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Black", "NVGoggles_OPFOR"};
     Items[] = {mag_8("ACE_fieldDressing")};
     respawnItems[] = {mag_8("ACE_fieldDressing")};
     weapons[] = {"TACU_MSF_W_Promet_Black", "TACU_MSF_W_Mk23_SOCOM", "Throw", "Put"};
@@ -43,8 +43,8 @@ class TACU_MSF_U_I_DDogs_Black_Rifleman_AT: TACU_MSF_U_I_DDogs_Black_Rifleman_01
     role = "MissileSpecialist";
     backpack = "TACU_MSF_B_AT_Black";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Black_Rifleman_AT.jpg);
-    weapons[] = {"TACU_MSF_W_Promet_Black", "TACU_MSF_W_Mk23_SOCOM", "CUP_launch_Mk153Mod0_blk", "Throw", "Put"};
-    respawnWeapons[] = {"TACU_MSF_W_Promet_Black", "TACU_MSF_W_Mk23_SOCOM", "CUP_launch_Mk153Mod0_blk", "Throw", "Put"};
+    weapons[] = {"TACU_MSF_W_Promet_Black", "TACU_MSF_W_Mk23_SOCOM", "tacs_MRAWS_Black_F", "Throw", "Put"};
+    respawnWeapons[] = {"TACU_MSF_W_Promet_Black", "TACU_MSF_W_Mk23_SOCOM", "tacs_MRAWS_Black_F", "Throw", "Put"};
     magazines[] = {mag_6("30Rnd_65x39_caseless_msbs_mag"), mag_3("CUP_12Rnd_45ACP_mk23"), mag_2("HandGrenade"), "SmokeShell"};
     respawnMagazines[] = {mag_6("30Rnd_65x39_caseless_msbs_mag"), mag_3("CUP_12Rnd_45ACP_mk23"), mag_2("HandGrenade"), "SmokeShell"};
 };

--- a/addons/msf/CfgVehicles_DDogs_Desert.hpp
+++ b/addons/msf/CfgVehicles_DDogs_Desert.hpp
@@ -2,8 +2,8 @@
 class TACU_MSF_U_I_DDogs_Desert_Rifleman_01: TACU_MSF_U_I_DDogs_Black_Rifleman_01 {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerDesert";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Desert_Rifleman_01.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
     headgearList[] = {
         "H_HelmetSpecB_sand", 1
     };
@@ -18,8 +18,8 @@ class TACU_MSF_U_I_DDogs_Desert_Rifleman_AT: TACU_MSF_U_I_DDogs_Black_Rifleman_A
     uniformClass = "TACU_MSF_Uniform_Combat_TigerDesert";
     backpack = "TACU_MSF_B_AT_Coyote";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Desert_Rifleman_AT.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
     headgearList[] = {
         "H_HelmetSpecB_sand", 1
     };
@@ -33,8 +33,8 @@ class TACU_MSF_U_O_DDogs_Desert_Rifleman_AT: TACU_MSF_U_I_DDogs_Desert_Rifleman_
 class TACU_MSF_U_I_DDogs_Desert_Autorifleman: TACU_MSF_U_I_DDogs_Black_Autorifleman {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerDesert";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Desert_Autorifleman.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
     headgearList[] = {
         "H_HelmetSpecB_sand", 1
     };
@@ -48,8 +48,8 @@ class TACU_MSF_U_O_DDogs_Desert_Autorifleman: TACU_MSF_U_I_DDogs_Desert_Autorifl
 class TACU_MSF_U_I_DDogs_Desert_Grenadier: TACU_MSF_U_I_DDogs_Black_Grenadier {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerDesert";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Desert_Grenadier.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
     headgearList[] = {
         "H_HelmetSpecB_sand", 1
     };
@@ -63,8 +63,8 @@ class TACU_MSF_U_O_DDogs_Desert_Grenadier: TACU_MSF_U_I_DDogs_Desert_Grenadier {
 class TACU_MSF_U_I_DDogs_Desert_Teamleader: TACU_MSF_U_I_DDogs_Black_Teamleader {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerDesert";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Desert_Teamleader.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
     headgearList[] = {
         "H_HelmetSpecB_sand", 1
     };
@@ -78,8 +78,8 @@ class TACU_MSF_U_O_DDogs_Desert_Teamleader: TACU_MSF_U_I_DDogs_Desert_Teamleader
 class TACU_MSF_U_I_DDogs_Desert_Marksman: TACU_MSF_U_I_DDogs_Black_Marksman {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerDesert";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Desert_Marksman.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
     headgearList[] = {
         "H_HelmetSpecB_sand", 1
     };
@@ -94,8 +94,8 @@ class TACU_MSF_U_I_DDogs_Desert_Medic: TACU_MSF_U_I_DDogs_Black_Medic {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerDesert";
     backpack = "TACU_MSF_B_Medic_Coyote";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Desert_Medic.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
     headgearList[] = {
         "H_HelmetSpecB_sand", 1
     };
@@ -110,8 +110,8 @@ class TACU_MSF_U_I_DDogs_Desert_Engineer: TACU_MSF_U_I_DDogs_Black_Engineer {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerDesert";
     backpack = "TACU_MSF_B_Medic_Coyote";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Desert_Engineer.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB_sand", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Coyote", "NVGoggles"};
     headgearList[] = {
         "H_HelmetSpecB_sand", 1
     };

--- a/addons/msf/CfgVehicles_DDogs_Wood.hpp
+++ b/addons/msf/CfgVehicles_DDogs_Wood.hpp
@@ -2,8 +2,8 @@
 class TACU_MSF_U_I_DDogs_Wood_Rifleman_01: TACU_MSF_U_I_DDogs_Black_Rifleman_01 {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerWood";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Wood_Rifleman_01.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
     headgearList[] = {
         "H_HelmetSpecB", 1
     };
@@ -18,8 +18,8 @@ class TACU_MSF_U_I_DDogs_Wood_Rifleman_AT: TACU_MSF_U_I_DDogs_Black_Rifleman_AT 
     uniformClass = "TACU_MSF_Uniform_Combat_TigerWood";
     backpack = "TACU_MSF_B_AT_Green";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Wood_Rifleman_AT.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
     headgearList[] = {
         "H_HelmetSpecB", 1
     };
@@ -33,8 +33,8 @@ class TACU_MSF_U_O_DDogs_Wood_Rifleman_AT: TACU_MSF_U_I_DDogs_Wood_Rifleman_AT {
 class TACU_MSF_U_I_DDogs_Wood_Autorifleman: TACU_MSF_U_I_DDogs_Black_Autorifleman {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerWood";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Wood_Autorifleman.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
     headgearList[] = {
         "H_HelmetSpecB", 1
     };
@@ -48,8 +48,8 @@ class TACU_MSF_U_O_DDogs_Wood_Autorifleman: TACU_MSF_U_I_DDogs_Wood_Autorifleman
 class TACU_MSF_U_I_DDogs_Wood_Grenadier: TACU_MSF_U_I_DDogs_Black_Grenadier {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerWood";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Wood_Grenadier.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
     headgearList[] = {
         "H_HelmetSpecB", 1
     };
@@ -63,8 +63,8 @@ class TACU_MSF_U_O_DDogs_Wood_Grenadier: TACU_MSF_U_I_DDogs_Wood_Grenadier {
 class TACU_MSF_U_I_DDogs_Wood_Teamleader: TACU_MSF_U_I_DDogs_Black_Teamleader {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerWood";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Wood_Teamleader.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
     headgearList[] = {
         "H_HelmetSpecB", 1
     };
@@ -78,8 +78,8 @@ class TACU_MSF_U_O_DDogs_Wood_Teamleader: TACU_MSF_U_I_DDogs_Wood_Teamleader {
 class TACU_MSF_U_I_DDogs_Wood_Marksman: TACU_MSF_U_I_DDogs_Black_Marksman {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerWood";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Wood_Marksman.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
     headgearList[] = {
         "H_HelmetSpecB", 1
     };
@@ -94,8 +94,8 @@ class TACU_MSF_U_I_DDogs_Wood_Medic: TACU_MSF_U_I_DDogs_Black_Medic {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerWood";
     backpack = "TACU_MSF_B_Medic_Green";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Wood_Medic.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
     headgearList[] = {
         "H_HelmetSpecB", 1
     };
@@ -110,8 +110,8 @@ class TACU_MSF_U_I_DDogs_Wood_Engineer: TACU_MSF_U_I_DDogs_Black_Engineer {
     uniformClass = "TACU_MSF_Uniform_Combat_TigerWood";
     backpack = "TACU_MSF_B_Medic_Green";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_DDogs_Wood_Engineer.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "CUP_NVG_PVS14"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetSpecB", "G_Balaclava_TI_G_blk_F", "TACU_MSF_Vest_HeavyPlateCarrier_Green", "NVGoggles_INDEP"};
     headgearList[] = {
         "H_HelmetSpecB", 1
     };

--- a/addons/msf/CfgVehicles_Regular_Black.hpp
+++ b/addons/msf/CfgVehicles_Regular_Black.hpp
@@ -45,8 +45,8 @@ class TACU_MSF_U_I_Regular_Black_Rifleman_AT: TACU_MSF_U_I_Regular_Black_Riflema
     uniformClass = "TACU_MSF_Uniform_Combat_Fatigues_LS_Black";
     backpack = "TACU_MSF_B_AT_Black";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_Regular_Black_Rifleman_AT.jpg);
-    weapons[] = {"TACU_MSF_W_ACRC_556_Black", "CUP_launch_Mk153Mod0_blk", "CUP_hgun_Mk23", "Throw", "Put"};
-    respawnWeapons[] = {"TACU_MSF_W_ACRC_556_Black", "CUP_launch_Mk153Mod0_blk", "CUP_hgun_Mk23", "Throw", "Put"};
+    weapons[] = {"TACU_MSF_W_ACRC_556_Black", "tacs_MRAWS_Black_Rail_F", "CUP_hgun_Mk23", "Throw", "Put"};
+    respawnWeapons[] = {"TACU_MSF_W_ACRC_556_Black", "tacs_MRAWS_Black_Rail_F", "CUP_hgun_Mk23", "Throw", "Put"};
     magazines[] = {mag_8("CUP_30Rnd_556x45_PMAG_QP"), mag_3("CUP_12Rnd_45ACP_mk23"), "HandGrenade", "SmokeShell"};
     respawnMagazines[] = {mag_8("CUP_30Rnd_556x45_PMAG_QP"), mag_3("CUP_12Rnd_45ACP_mk23"), "HandGrenade", "SmokeShell"};
 };
@@ -251,8 +251,8 @@ class TACU_MSF_U_I_Regular_Black_Pilot: TACU_MSF_U_I_Regular_Black_Rifleman_01 {
     engineer = 1;
     uniformClass = "TACU_MSF_Uniform_Combat_Fatigues_RS_Olive";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_Regular_Black_Pilot.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_PilotHelmetHeli_B", "G_Balaclava_TI_blk_F", "TACU_MSF_Vest_ChestRig_Black", "NVGogglesB_blk_F"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_PilotHelmetHeli_B", "G_Balaclava_TI_blk_F", "TACU_MSF_Vest_ChestRig_Black", "NVGogglesB_blk_F"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_PilotHelmetHeli_B", "G_Balaclava_TI_blk_F", "TACU_MSF_Vest_ChestRig_Black", "ACE_NVG_Wide"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_PilotHelmetHeli_B", "G_Balaclava_TI_blk_F", "TACU_MSF_Vest_ChestRig_Black", "ACE_NVG_Wide"};
     weapons[] = {"CUP_hgun_Mk23", "Throw", "Put"};
     respawnWeapons[] = {"CUP_hgun_Mk23", "Throw", "Put"};
     magazines[] = {mag_4("CUP_12Rnd_45ACP_mk23"), mag_2("SmokeShell")};
@@ -270,8 +270,8 @@ class TACU_MSF_U_I_Regular_Black_Crewman: TACU_MSF_U_I_Regular_Black_Pilot {
     displayName = "Crewman";
     uniformClass = "TACU_MSF_Uniform_Combat_Fatigues_RS_Olive";
     editorPreview = QPATHTOF(ui\eden\MSF_U_I_Regular_Black_Crewman.jpg);
-    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetCrew_B", "G_Balaclava_TI_blk_F", "TACU_MSF_Vest_ChestRig_Black", "NVGogglesB_blk_F"};
-    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetCrew_B", "G_Balaclava_TI_blk_F", "TACU_MSF_Vest_ChestRig_Black", "NVGogglesB_blk_F"};
+    linkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetCrew_B", "G_Balaclava_TI_blk_F", "TACU_MSF_Vest_ChestRig_Black", "ACE_NVG_Wide"};
+    respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_HelmetCrew_B", "G_Balaclava_TI_blk_F", "TACU_MSF_Vest_ChestRig_Black", "ACE_NVG_Wide"};
     headgearList[] = {
         "H_HelmetCrew_B", 1
     };

--- a/addons/msf/CfgWeapons.hpp
+++ b/addons/msf/CfgWeapons.hpp
@@ -935,7 +935,7 @@ class CfgWeapons {
         scopeCurator = 1;
         class LinkedItems {
             EQUIP_OPTIC(cup_optic_acog2);
-            EQUIP_POINTER(cup_acc_anpeq_15_black);
+            EQUIP_POINTER(cup_acc_flashlight);
             EQUIP_BIPOD(cup_bipod_vltor_modpod_black);
         };
     };


### PR DESCRIPTION
- Light AT units now use the black MAAWS
- Switched the Viper Light Harness as the backpack
- Updated some NVGs used by DDogs and Pilots/Crew
- Corrected a weapon attachment for regular marksmen

Note: Requires next Theseus Services update which adds the black MAAWS and coyote/green viper backpacks