### PR TITLE
Upgrade Units Ammunition

### DIFF
--- a/addons/cartel/CfgVehicles_Sicarios.hpp
+++ b/addons/cartel/CfgVehicles_Sicarios.hpp
@@ -36,8 +36,8 @@ class TACU_Cartel_U_O_Sicario_Rifleman_02: TACU_Cartel_U_O_Sicario_Rifleman_01 {
     uniformClass = "tacs_Suit_VIP";
     weapons[] = {"CUP_arifle_AKS_Gold", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKS_Gold", "Throw", "Put"};
-    magazines[] = {mag_2("CUP_30Rnd_762x39_AK47_M"), mag_2("HandGrenade"), "SmokeShell"};
-    respawnMagazines[] = {mag_2("CUP_30Rnd_762x39_AK47_M"), mag_2("HandGrenade"), "SmokeShell"};
+    magazines[] = {mag_2("tacgt_30Rnd_762x39_BP_Mag"), mag_2("HandGrenade"), "SmokeShell"};
+    respawnMagazines[] = {mag_2("tacgt_30Rnd_762x39_BP_Mag"), mag_2("HandGrenade"), "SmokeShell"};
     editorPreview = QPATHTOF(ui\Cartel_U_O_Sicario_Rifleman_02.jpg);
 };
 
@@ -48,8 +48,8 @@ class TACU_Cartel_U_O_Sicario_Rifleman_03: TACU_Cartel_U_O_Sicario_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "V_PlateCarrierIA1_dgtl", "G_Aviator"};
     weapons[] = {"CUP_arifle_AKS74_top_rail", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKS74_top_rail", "Throw", "Put"};
-    magazines[] = {mag_2("CUP_30Rnd_545x39_AK_M"), mag_2("HandGrenade"), "SmokeShell"};
-    respawnMagazines[] = {mag_2("CUP_30Rnd_545x39_AK_M"), mag_2("HandGrenade"), "SmokeShell"};
+    magazines[] = {mag_2("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), "SmokeShell"};
+    respawnMagazines[] = {mag_2("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), "SmokeShell"};
     editorPreview = QPATHTOF(ui\Cartel_U_O_Sicario_Rifleman_03.jpg);
 };
 
@@ -88,8 +88,8 @@ class TACU_Cartel_U_O_Sicario_Rifleman_MG: TACU_Cartel_U_O_Sicario_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "V_PlateCarrierIA1_dgtl", "G_Aviator"};
     weapons[] = {"LMG_03_F", "Throw", "Put"};
     respawnWeapons[] = {"LMG_03_F", "Throw", "Put"};
-    magazines[] = {mag_2("200Rnd_556x45_Box_F"), mag_2("HandGrenade"), "SmokeShell"};
-    respawnMagazines[] = {mag_2("200Rnd_556x45_Box_F"), mag_2("HandGrenade"), "SmokeShell"};
+    magazines[] = {mag_2("tacgt_200Rnd_556x45_M855A1_Box_Red"), mag_2("HandGrenade"), "SmokeShell"};
+    respawnMagazines[] = {mag_2("tacgt_200Rnd_556x45_M855A1_Box_Red"), mag_2("HandGrenade"), "SmokeShell"};
     editorPreview = QPATHTOF(ui\Cartel_U_O_Sicario_Rifleman_MG.jpg);
 };
 
@@ -100,7 +100,7 @@ class TACU_Cartel_U_O_Sicario_Grenadier: TACU_Cartel_U_O_Sicario_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "V_PlateCarrierIA1_dgtl", "G_Aviator"};
     weapons[] = {"CUP_arifle_AK74_GL", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AK74_GL", "Throw", "Put"};
-    magazines[] = {mag_2("CUP_30Rnd_545x39_AK_M"), mag_2("HandGrenade"), mag_3("CUP_1Rnd_HE_GP25_M"), "SmokeShell"};
-    respawnMagazines[] = {mag_2("CUP_30Rnd_545x39_AK_M"), mag_2("HandGrenade"), mag_3("CUP_1Rnd_HE_GP25_M"), "SmokeShell"};
+    magazines[] = {mag_2("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), mag_3("CUP_1Rnd_HE_GP25_M"), "SmokeShell"};
+    respawnMagazines[] = {mag_2("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), mag_3("CUP_1Rnd_HE_GP25_M"), "SmokeShell"};
     editorPreview = QPATHTOF(ui\Cartel_U_O_Sicario_Grenadier.jpg);
 };

--- a/addons/cartel/CfgVehicles_Soldados.hpp
+++ b/addons/cartel/CfgVehicles_Soldados.hpp
@@ -45,8 +45,8 @@ class TACU_Cartel_U_O_Soldado_Rifleman_01: TACU_Cartel_U_O_Soldado_Rifleman {
     respawnItems[] = {mag_5("ACE_fieldDressing")};
     weapons[] = {"arifle_AKS_F", "Throw", "Put"};
     respawnWeapons[] = {"arifle_AKS_F", "Throw", "Put"};
-    magazines[] = {mag_7("30Rnd_545x39_Mag_F"), mag_2("HandGrenade"), "SmokeShell"};
-    respawnMagazines[] = {mag_7("30Rnd_545x39_Mag_F"), mag_2("HandGrenade"), "SmokeShell"};
+    magazines[] = {mag_7("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), "SmokeShell"};
+    respawnMagazines[] = {mag_7("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), "SmokeShell"};
     editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_01.jpg);
 };
 
@@ -57,8 +57,8 @@ class TACU_Cartel_U_O_Soldado_Rifleman_02: TACU_Cartel_U_O_Soldado_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_Bandanna_gry", "V_BandollierB_blk"};
     weapons[] = {"arifle_AK12_F", "Throw", "Put"};
     respawnWeapons[] = {"arifle_AK12_F", "Throw", "Put"};
-    magazines[] = {mag_7("30Rnd_762x39_Mag_F"), mag_2("HandGrenade"), "SmokeShell"};
-    respawnMagazines[] = {mag_7("30Rnd_762x39_Mag_F"), mag_2("HandGrenade"), "SmokeShell"};
+    magazines[] = {mag_7("tacgt_30Rnd_762x39_BP_Mag"), mag_2("HandGrenade"), "SmokeShell"};
+    respawnMagazines[] = {mag_7("tacgt_30Rnd_762x39_BP_Mag"), mag_2("HandGrenade"), "SmokeShell"};
     editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_02.jpg);
 };
 
@@ -93,8 +93,8 @@ class TACU_Cartel_U_O_Soldado_Driver: TACU_Cartel_U_O_Soldado_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_Bandanna_gry", "V_BandollierB_blk"};
     weapons[] = {"arifle_AKS_F", "Throw", "Put"};
     respawnWeapons[] = {"arifle_AKS_F", "Throw", "Put"};
-    magazines[] = {mag_7("30Rnd_545x39_Mag_F"), mag_2("HandGrenade"), "SmokeShell"};
-    respawnMagazines[] = {mag_7("30Rnd_545x39_Mag_F"), mag_2("HandGrenade"), "SmokeShell"};
+    magazines[] = {mag_7("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), "SmokeShell"};
+    respawnMagazines[] = {mag_7("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), "SmokeShell"};
     editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Driver.jpg);
 };
 
@@ -107,8 +107,8 @@ class TACU_Cartel_U_O_Soldado_Rifleman_AT: TACU_Cartel_U_O_Soldado_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_Bandanna_gry", "V_BandollierB_blk"};
     weapons[] = {"arifle_AKS_F", "CUP_launch_RPG7V", "Throw", "Put"};
     respawnWeapons[] = {"arifle_AKS_F", "CUP_launch_RPG7V", "Throw", "Put"};
-    magazines[] = {mag_7("30Rnd_545x39_Mag_F"), mag_2("HandGrenade"), "RPG7_F", "SmokeShell"};
-    respawnMagazines[] = {mag_7("30Rnd_545x39_Mag_F"), mag_2("HandGrenade"), "RPG7_F", "SmokeShell"};
+    magazines[] = {mag_7("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), "RPG7_F", "SmokeShell"};
+    respawnMagazines[] = {mag_7("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), "RPG7_F", "SmokeShell"};
     editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_AT.jpg);
 };
 
@@ -121,8 +121,8 @@ class TACU_Cartel_U_O_Soldado_Rifleman_MG: TACU_Cartel_U_O_Soldado_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_Bandanna_gry", "V_BandollierB_blk"};
     weapons[] = {"CUP_arifle_RPK74", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_RPK74", "Throw", "Put"};
-    magazines[] = {mag_4("CUP_75Rnd_TE4_LRT4_Green_Tracer_762x39_RPK_M"), mag_2("HandGrenade"), "SmokeShell"};
-    respawnMagazines[] = {mag_4("CUP_75Rnd_TE4_LRT4_Green_Tracer_762x39_RPK_M"), mag_2("HandGrenade"), "SmokeShell"};
+    magazines[] = {mag_4("tacgt_75Rnd_762x39_RPK_BP_Mag"), mag_2("HandGrenade"), "SmokeShell"};
+    respawnMagazines[] = {mag_4("tacgt_75Rnd_762x39_RPK_BP_Mag"), mag_2("HandGrenade"), "SmokeShell"};
     editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Rifleman_MG.jpg);
 };
 
@@ -133,8 +133,8 @@ class TACU_Cartel_U_O_Soldado_Grenadier: TACU_Cartel_U_O_Soldado_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "H_Bandanna_gry", "V_BandollierB_blk"};
     weapons[] = {"CUP_arifle_AKS74_GL_Early", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKS74_GL_Early", "Throw", "Put"};
-    magazines[] = {mag_4("CUP_30Rnd_545x39_AK_M"), mag_2("HandGrenade"), mag_3("CUP_1Rnd_HE_GP25_M"), "SmokeShell"};
-    respawnMagazines[] = {mag_4("CUP_30Rnd_545x39_AK_M"), mag_2("HandGrenade"), mag_3("CUP_1Rnd_HE_GP25_M"), "SmokeShell"};
+    magazines[] = {mag_4("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), mag_3("CUP_1Rnd_HE_GP25_M"), "SmokeShell"};
+    respawnMagazines[] = {mag_4("tacgt_30Rnd_545x39_BT_Mag_Bakelite"), mag_2("HandGrenade"), mag_3("CUP_1Rnd_HE_GP25_M"), "SmokeShell"};
     editorPreview = QPATHTOF(ui\Cartel_U_O_Soldado_Grenadier.jpg);
 };
 

--- a/addons/police/CfgVehicles_B.hpp
+++ b/addons/police/CfgVehicles_B.hpp
@@ -14,8 +14,8 @@ class TACU_Police_U_B_CT_Rifleman: TACU_Main_U_BLUFOR_Soldier_Base {
     respawnItems[] = {mag_5("ACE_fieldDressing")};
     weapons[] = {"TACU_Police_W_HK416_CQB", "CUP_hgun_Glock17_blk", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Police_W_HK416_CQB", "CUP_hgun_Glock17_blk", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_PMAG_QP"), mag_3("CUP_17Rnd_9x19_glock17"), mag_2("ACE_M84"), "CUP_HandGrenade_M67", "SmokeShell"};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_PMAG_QP"), mag_3("CUP_17Rnd_9x19_glock17"), mag_2("ACE_M84"), "CUP_HandGrenade_M67", "SmokeShell"};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_PMAG"), mag_3("CUP_17Rnd_9x19_glock17"), mag_2("ACE_M84"), "CUP_HandGrenade_M67", "SmokeShell"};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_PMAG"), mag_3("CUP_17Rnd_9x19_glock17"), mag_2("ACE_M84"), "CUP_HandGrenade_M67", "SmokeShell"};
     headgearList[] = {
         "BWA3_OpsCore", 0.50,
         "BWA3_OpsCore_Camera", 0.50
@@ -33,8 +33,8 @@ class TACU_Police_U_B_CT_Breacher: TACU_Police_U_B_CT_Rifleman {
     editorPreview = QPATHTOF(ui\Police_U_B_CT_Breacher.jpg);
     weapons[] = {"CUP_sgun_M1014", "CUP_hgun_Glock17_blk", "Throw", "Put"};
     respawnWeapons[] = {"CUP_sgun_M1014", "CUP_hgun_Glock17_blk", "Throw", "Put"};
-    magazines[] = {mag_8("CUP_8Rnd_B_Beneli_74Pellets"), mag_3("CUP_17Rnd_9x19_glock17"), mag_2("ACE_M84"), "CUP_HandGrenade_M67", "SmokeShell"};
-    respawnMagazines[] = {mag_8("CUP_8Rnd_B_Beneli_74Pellets"), mag_3("CUP_17Rnd_9x19_glock17"), mag_2("ACE_M84"), "CUP_HandGrenade_M67", "SmokeShell"};
+    magazines[] = {mag_8("tacgt_8Rnd_P_000"), mag_3("CUP_17Rnd_9x19_glock17"), mag_2("ACE_M84"), "CUP_HandGrenade_M67", "SmokeShell"};
+    respawnMagazines[] = {mag_8("tacgt_8Rnd_P_000"), mag_3("CUP_17Rnd_9x19_glock17"), mag_2("ACE_M84"), "CUP_HandGrenade_M67", "SmokeShell"};
 };
 
 class TACU_Police_U_B_CT_Marksman: TACU_Police_U_B_CT_Rifleman {
@@ -42,8 +42,8 @@ class TACU_Police_U_B_CT_Marksman: TACU_Police_U_B_CT_Rifleman {
     editorPreview = QPATHTOF(ui\Police_U_B_CT_Marksman.jpg);
     weapons[] = {"TACU_Police_W_HK417_DMR", "CUP_hgun_Glock17_blk", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Police_W_HK417_DMR", "CUP_hgun_Glock17_blk", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_20Rnd_762x51_HK417"), mag_3("CUP_17Rnd_9x19_glock17")};
-    respawnMagazines[] = {mag_6("CUP_20Rnd_762x51_HK417"), mag_3("CUP_17Rnd_9x19_glock17")};
+    magazines[] = {mag_6("ACE_20Rnd_762x51_M993_AP_Mag"), mag_3("CUP_17Rnd_9x19_glock17")};
+    respawnMagazines[] = {mag_6("ACE_20Rnd_762x51_M993_AP_Mag"), mag_3("CUP_17Rnd_9x19_glock17")};
 };
 
 class TACU_Police_U_B_CT_RiotControl: TACU_Police_U_B_CT_Rifleman {
@@ -71,8 +71,8 @@ class TACU_Police_U_B_Enforcer_Rifleman: TACU_Main_U_BLUFOR_Soldier_Base {
     respawnItems[] = {mag_5("ACE_fieldDressing")};
     weapons[] = {"CUP_arifle_M4A3_black", "CUP_hgun_Glock17_blk", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_M4A3_black", "CUP_hgun_Glock17_blk", "Throw", "Put"};
-    magazines[] = {mag_4("CUP_30Rnd_556x45_Stanag"), mag_3("CUP_17Rnd_9x19_glock17")};
-    respawnMagazines[] = {mag_4("CUP_30Rnd_556x45_Stanag"), mag_3("CUP_17Rnd_9x19_glock17")};
+    magazines[] = {mag_4("tacgt_30Rnd_556x45_M855A1_PMAG"), mag_3("CUP_17Rnd_9x19_glock17")};
+    respawnMagazines[] = {mag_4("tacgt_30Rnd_556x45_M855A1_PMAG"), mag_3("CUP_17Rnd_9x19_glock17")};
     headgearList[] = {
         "H_Cap_police", 0.60,
         "H_MilCap_blue", 0.50,
@@ -113,8 +113,8 @@ class TACU_Police_U_B_Enforcer_Breacher: TACU_Police_U_B_Enforcer_Rifleman {
     editorPreview = QPATHTOF(ui\Police_U_B_Enforcer_Breacher.jpg);
     weapons[] = {"CUP_sgun_M1014", "CUP_hgun_Glock17_blk", "Throw", "Put"};
     respawnWeapons[] = {"CUP_sgun_M1014", "CUP_hgun_Glock17_blk", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_8Rnd_B_Beneli_74Pellets"), mag_3("CUP_17Rnd_9x19_glock17")};
-    respawnMagazines[] = {mag_6("CUP_8Rnd_B_Beneli_74Pellets"), mag_3("CUP_17Rnd_9x19_glock17")};
+    magazines[] = {mag_6("tacgt_8Rnd_P_000"), mag_3("CUP_17Rnd_9x19_glock17")};
+    respawnMagazines[] = {mag_6("tacgt_8Rnd_P_000"), mag_3("CUP_17Rnd_9x19_glock17")};
 };
 
 // Vehicles

--- a/addons/police/CfgVehicles_I.hpp
+++ b/addons/police/CfgVehicles_I.hpp
@@ -16,8 +16,8 @@ class TACU_Police_U_I_CT_Rifleman: TACU_Main_U_INDEP_Soldier_Base {
     respawnItems[] = {mag_5("ACE_fieldDressing")};
     weapons[] = {"TACU_Police_W_SG551LB_TAC", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Police_W_SG551LB_TAC", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("hlc_30Rnd_556x45_EPR_sg550"), mag_3("CUP_15Rnd_9x19_M9"), mag_2("ACE_M84"), "MiniGrenade", "SmokeShell"};
-    respawnMagazines[] = {mag_6("hlc_30Rnd_556x45_EPR_sg550"), mag_3("CUP_15Rnd_9x19_M9"), mag_2("ACE_M84"), "MiniGrenade", "SmokeShell"};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_SG550"), mag_3("CUP_15Rnd_9x19_M9"), mag_2("ACE_M84"), "MiniGrenade", "SmokeShell"};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_SG550"), mag_3("CUP_15Rnd_9x19_M9"), mag_2("ACE_M84"), "MiniGrenade", "SmokeShell"};
     headgearList[] = {
         "TACU_Police_Helmet_PASGT_Neck_PoliceBlack", 1
     };
@@ -42,8 +42,8 @@ class TACU_Police_U_I_CT_Marksman: TACU_Police_U_I_CT_Rifleman {
     editorPreview = QPATHTOF(ui\Police_U_I_CT_Marksman.jpg);
     weapons[] = {"TACU_Police_W_SG5501_DMR_Rail", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Police_W_SG5501_DMR_Rail", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("hlc_30Rnd_556x45_EPR_sg550"), mag_3("CUP_15Rnd_9x19_M9")};
-    respawnMagazines[] = {mag_6("hlc_30Rnd_556x45_EPR_sg550"), mag_3("CUP_15Rnd_9x19_M9")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_SG550"), mag_3("CUP_15Rnd_9x19_M9")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_SG550"), mag_3("CUP_15Rnd_9x19_M9")};
 };
 
 class TACU_Police_U_I_CT_RiotControl: TACU_Police_U_I_CT_Rifleman {
@@ -73,8 +73,8 @@ class TACU_Police_U_I_Enforcer_Rifleman: TACU_Main_U_INDEP_Soldier_Base {
     respawnItems[] = {mag_5("ACE_fieldDressing")};
     weapons[] = {"CUP_arifle_G36C", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_G36C", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_G36"), mag_3("CUP_15Rnd_9x19_M9")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_G36"), mag_3("CUP_15Rnd_9x19_M9")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_G36"), mag_3("CUP_15Rnd_9x19_M9")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_G36"), mag_3("CUP_15Rnd_9x19_M9")};
     headgearList[] = {
         "H_Cap_blk", 0.60,
         "CUP_H_PMC_Cap_Grey", 0.40,

--- a/addons/police/CfgVehicles_O.hpp
+++ b/addons/police/CfgVehicles_O.hpp
@@ -63,8 +63,8 @@ class TACU_Police_U_O_CT_Marksman: TACU_Police_U_O_CT_Rifleman {
     editorPreview = QPATHTOF(ui\Police_U_O_CT_Marksman.jpg);
     weapons[] = {"TACU_Police_W_Dragunov", "hgun_Rook40_F", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Police_W_Dragunov", "hgun_Rook40_F", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_10Rnd_762x54_SVD_M"), mag_3("16Rnd_9x21_Mag")};
-    respawnMagazines[] = {mag_6("CUP_10Rnd_762x54_SVD_M"), mag_3("16Rnd_9x21_Mag")};
+    magazines[] = {mag_6("tacgt_10Rnd_762x54_SVD_AP_Mag"), mag_3("16Rnd_9x21_Mag")};
+    respawnMagazines[] = {mag_6("tacgt_10Rnd_762x54_SVD_AP_Mag"), mag_3("16Rnd_9x21_Mag")};
 };
 
 // Units - Police (Enforcers)

--- a/addons/revolutionaries/CfgVehicles_I_Russian.hpp
+++ b/addons/revolutionaries/CfgVehicles_I_Russian.hpp
@@ -20,8 +20,8 @@ class TACU_Revolutionaries_U_I_Russian_Rifleman01: TACU_Main_U_INDEP_Soldier_Bas
     respawnItems[] = {mag_5("ACE_fieldDressing")};
     weapons[] = {"CUP_arifle_FNFAL", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_FNFAL", "Throw", "Put"};
-    magazines[] = {mag_5("CUP_20Rnd_762x51_FNFAL_M")};
-    respawnMagazines[] = {mag_5("CUP_20Rnd_762x51_FNFAL_M")};
+    magazines[] = {mag_5("tacgt_20Rnd_762x51_FAL_AP_Mag")};
+    respawnMagazines[] = {mag_5("tacgt_20Rnd_762x51_FAL_AP_Mag")};
     editorSubcategory = "TACU_Revolutionaries_EdSubCat_Russian";
     editorPreview = QPATHTOF(ui\Revolutionaries_U_I_Russian_Rifleman01.jpg);
     headgearList[] = {
@@ -60,8 +60,8 @@ class TACU_Revolutionaries_U_I_Russian_Paramedic: TACU_Revolutionaries_U_I_Russi
     uniformClass = "CUP_U_C_Rocker_02";
     weapons[] = {"sgun_HunterShotgun_01_sawedoff_F", "Throw", "Put"};
     respawnWeapons[] = {"sgun_HunterShotgun_01_sawedoff_F", "Throw", "Put"};
-    magazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
-    respawnMagazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
+    magazines[] = {mag_12("tacgt_2Rnd_P_000")};
+    respawnMagazines[] = {mag_12("tacgt_2Rnd_P_000")};
     backpack = "TACU_Revolutionaries_B_Paramedic_Black";
     editorPreview = QPATHTOF(ui\Revolutionaries_U_I_Russian_Paramedic.jpg);
 };
@@ -71,8 +71,8 @@ class TACU_Revolutionaries_U_I_Russian_Shotgunner: TACU_Revolutionaries_U_I_Russ
     uniformClass = "CUP_U_C_Citizen_03";
     weapons[] = {"sgun_HunterShotgun_01_F", "Throw", "Put"};
     respawnWeapons[] = {"sgun_HunterShotgun_01_F", "Throw", "Put"};
-    magazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
-    respawnMagazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
+    magazines[] = {mag_12("tacgt_2Rnd_P_000")};
+    respawnMagazines[] = {mag_12("tacgt_2Rnd_P_000")};
     editorPreview = QPATHTOF(ui\Revolutionaries_U_I_Russian_Shotgunner.jpg);
 };
 

--- a/addons/revolutionaries/CfgVehicles_I_Tanoan.hpp
+++ b/addons/revolutionaries/CfgVehicles_I_Tanoan.hpp
@@ -20,8 +20,8 @@ class TACU_Revolutionaries_U_I_Tanoan_Rifleman01: TACU_Main_U_INDEP_Soldier_Base
     respawnItems[] = {mag_5("ACE_fieldDressing")};
     weapons[] = {"CUP_arifle_FNFAL", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_FNFAL", "Throw", "Put"};
-    magazines[] = {mag_5("CUP_20Rnd_762x51_FNFAL_M")};
-    respawnMagazines[] = {mag_5("CUP_20Rnd_762x51_FNFAL_M")};
+    magazines[] = {mag_5("tacgt_20Rnd_762x51_FAL_AP_Mag")};
+    respawnMagazines[] = {mag_5("tacgt_20Rnd_762x51_FAL_AP_Mag")};
     editorSubcategory = "TACU_Revolutionaries_EdSubCat_Tanoan";
     editorPreview = QPATHTOF(ui\Revolutionaries_U_I_Tanoan_Rifleman01.jpg);
     headgearList[] = {
@@ -60,8 +60,8 @@ class TACU_Revolutionaries_U_I_Tanoan_Paramedic: TACU_Revolutionaries_U_I_Tanoan
     uniformClass = "U_C_Poloshirt_burgundy";
     weapons[] = {"sgun_HunterShotgun_01_sawedoff_F", "Throw", "Put"};
     respawnWeapons[] = {"sgun_HunterShotgun_01_sawedoff_F", "Throw", "Put"};
-    magazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
-    respawnMagazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
+    magazines[] = {mag_12("tacgt_2Rnd_P_000")};
+    respawnMagazines[] = {mag_12("tacgt_2Rnd_P_000")};
     backpack = "TACU_Revolutionaries_B_Paramedic_Green";
     editorPreview = QPATHTOF(ui\Revolutionaries_U_I_Tanoan_Paramedic.jpg);
 };
@@ -71,8 +71,8 @@ class TACU_Revolutionaries_U_I_Tanoan_Shotgunner: TACU_Revolutionaries_U_I_Tanoa
     uniformClass = "U_C_MAN_casual_3_F";
     weapons[] = {"sgun_HunterShotgun_01_F", "Throw", "Put"};
     respawnWeapons[] = {"sgun_HunterShotgun_01_F", "Throw", "Put"};
-    magazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
-    respawnMagazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
+    magazines[] = {mag_12("tacgt_2Rnd_P_000")};
+    respawnMagazines[] = {mag_12("tacgt_2Rnd_P_000")};
     editorPreview = QPATHTOF(ui\Revolutionaries_U_I_Tanoan_Shotgunner.jpg);
 };
 

--- a/addons/revolutionaries/CfgVehicles_O_Russian.hpp
+++ b/addons/revolutionaries/CfgVehicles_O_Russian.hpp
@@ -20,8 +20,8 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman01: TACU_Main_U_OPFOR_Soldier_Bas
     respawnItems[] = {mag_5("ACE_fieldDressing")};
     weapons[] = {"CUP_arifle_FNFAL", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_FNFAL", "Throw", "Put"};
-    magazines[] = {mag_5("CUP_20Rnd_762x51_FNFAL_M")};
-    respawnMagazines[] = {mag_5("CUP_20Rnd_762x51_FNFAL_M")};
+    magazines[] = {mag_5("tacgt_20Rnd_762x51_FAL_AP_Mag")};
+    respawnMagazines[] = {mag_5("tacgt_20Rnd_762x51_FAL_AP_Mag")};
     editorSubcategory = "TACU_Revolutionaries_EdSubCat_Russian";
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Russian_Rifleman01.jpg);
     headgearList[] = {
@@ -59,8 +59,8 @@ class TACU_Revolutionaries_U_O_Russian_Rifleman04: TACU_Revolutionaries_U_O_Russ
     respawnLinkedItems[] = {DEFAULT_ITEMS, "CUP_V_C_Police_Holster", "G_Balaclava_blk"};
     weapons[] = {"TACU_Revolutionaries_W_CZ805A2", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Revolutionaries_W_CZ805A2", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_G36")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_G36")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_G36")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_G36")};
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Russian_Rifleman04.jpg);
 };
 
@@ -72,8 +72,8 @@ class TACU_Revolutionaries_U_O_Russian_Paramedic: TACU_Revolutionaries_U_O_Russi
     uniformClass = "CUP_U_C_Rocker_02";
     weapons[] = {"sgun_HunterShotgun_01_sawedoff_F", "Throw", "Put"};
     respawnWeapons[] = {"sgun_HunterShotgun_01_sawedoff_F", "Throw", "Put"};
-    magazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
-    respawnMagazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
+    magazines[] = {mag_12("tacgt_2Rnd_P_000")};
+    respawnMagazines[] = {mag_12("tacgt_2Rnd_P_000")};
     backpack = "TACU_Revolutionaries_B_Paramedic_Black";
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Russian_Paramedic.jpg);
 };
@@ -83,8 +83,8 @@ class TACU_Revolutionaries_U_O_Russian_Shotgunner: TACU_Revolutionaries_U_O_Russ
     uniformClass = "CUP_U_C_Citizen_03";
     weapons[] = {"sgun_HunterShotgun_01_F", "Throw", "Put"};
     respawnWeapons[] = {"sgun_HunterShotgun_01_F", "Throw", "Put"};
-    magazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
-    respawnMagazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
+    magazines[] = {mag_12("tacgt_2Rnd_P_000")};
+    respawnMagazines[] = {mag_12("tacgt_2Rnd_P_000")};
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Russian_Shotgunner.jpg);
 };
 
@@ -160,8 +160,8 @@ class TACU_Revolutionaries_U_O_Russian_Autorifleman: TACU_Revolutionaries_U_O_Ru
     backpack = "TACU_Revolutionaries_B_LMG_Minimi_Black";
     weapons[] = {"TACU_Revolutionaries_W_FNMinimiSPW", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Revolutionaries_W_FNMinimiSPW", "Throw", "Put"};
-    magazines[] = {"200Rnd_556x45_Box_F"};
-    respawnMagazines[] = {"200Rnd_556x45_Box_F"};
+    magazines[] = {"tacgt_200Rnd_556x45_M855A1_Box_Red"};
+    respawnMagazines[] = {"tacgt_200Rnd_556x45_M855A1_Box_Red"};
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Russian_Autorifleman.jpg);
 };
 
@@ -201,8 +201,8 @@ class TACU_Revolutionaries_U_O_Russian_Leader: TACU_Revolutionaries_U_O_Russian_
     respawnLinkedItems[] = {DEFAULT_ITEMS, "V_LegStrapBag_black_F", "CUP_H_USMC_BOONIE_PRR_WDL", "G_Balaclava_blk"};
     weapons[] = {"TACU_Revolutionaries_W_CZ805_GL", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Revolutionaries_W_CZ805_GL", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_G36"), mag_6("1Rnd_HE_Grenade_shell")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_G36"), mag_6("1Rnd_HE_Grenade_shell")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_G36"), mag_6("1Rnd_HE_Grenade_shell")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_G36"), mag_6("1Rnd_HE_Grenade_shell")};
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Russian_Leader.jpg);
     headgearList[] = {
         "CUP_H_USMC_BOONIE_PRR_WDL", 1

--- a/addons/revolutionaries/CfgVehicles_O_Tanoan.hpp
+++ b/addons/revolutionaries/CfgVehicles_O_Tanoan.hpp
@@ -20,8 +20,8 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman01: TACU_Main_U_OPFOR_Soldier_Base
     respawnItems[] = {mag_5("ACE_fieldDressing")};
     weapons[] = {"CUP_arifle_FNFAL", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_FNFAL", "Throw", "Put"};
-    magazines[] = {mag_5("CUP_20Rnd_762x51_FNFAL_M")};
-    respawnMagazines[] = {mag_5("CUP_20Rnd_762x51_FNFAL_M")};
+    magazines[] = {mag_5("tacgt_20Rnd_762x51_FAL_AP_Mag")};
+    respawnMagazines[] = {mag_5("tacgt_20Rnd_762x51_FAL_AP_Mag")};
     editorSubcategory = "TACU_Revolutionaries_EdSubCat_Tanoan";
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Tanoan_Rifleman01.jpg);
     headgearList[] = {
@@ -59,8 +59,8 @@ class TACU_Revolutionaries_U_O_Tanoan_Rifleman04: TACU_Revolutionaries_U_O_Tanoa
     uniformClass = "U_C_Poloshirt_tricolour";
     weapons[] = {"TACU_Revolutionaries_W_CZ805A2", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Revolutionaries_W_CZ805A2", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_G36")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_G36")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_G36")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_G36")};
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Tanoan_Rifleman04.jpg);
 };
 
@@ -72,8 +72,8 @@ class TACU_Revolutionaries_U_O_Tanoan_Paramedic: TACU_Revolutionaries_U_O_Tanoan
     uniformClass = "U_C_Poloshirt_burgundy";
     weapons[] = {"sgun_HunterShotgun_01_sawedoff_F", "Throw", "Put"};
     respawnWeapons[] = {"sgun_HunterShotgun_01_sawedoff_F", "Throw", "Put"};
-    magazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
-    respawnMagazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
+    magazines[] = {mag_12("tacgt_2Rnd_P_000")};
+    respawnMagazines[] = {mag_12("tacgt_2Rnd_P_000")};
     backpack = "TACU_Revolutionaries_B_Paramedic_Green";
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Tanoan_Paramedic.jpg);
 };
@@ -85,8 +85,8 @@ class TACU_Revolutionaries_U_O_Tanoan_Shotgunner: TACU_Revolutionaries_U_O_Tanoa
     respawnLinkedItems[] = {DEFAULT_ITEMS, "V_Pocketed_black_F", "G_Balaclava_blk"};
     weapons[] = {"sgun_HunterShotgun_01_F", "Throw", "Put"};
     respawnWeapons[] = {"sgun_HunterShotgun_01_F", "Throw", "Put"};
-    magazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
-    respawnMagazines[] = {mag_12("2Rnd_12Gauge_Pellets")};
+    magazines[] = {mag_12("tacgt_2Rnd_P_000")};
+    respawnMagazines[] = {mag_12("tacgt_2Rnd_P_000")};
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Tanoan_Shotgunner.jpg);
 };
 
@@ -162,8 +162,8 @@ class TACU_Revolutionaries_U_O_Tanoan_Autorifleman: TACU_Revolutionaries_U_O_Tan
     backpack = "TACU_Revolutionaries_B_LMG_Minimi_Green";
     weapons[] = {"TACU_Revolutionaries_W_FNMinimiSPW", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Revolutionaries_W_FNMinimiSPW", "Throw", "Put"};
-    magazines[] = {"200Rnd_556x45_Box_F"};
-    respawnMagazines[] = {"200Rnd_556x45_Box_F"};
+    magazines[] = {"tacgt_200Rnd_556x45_M855A1_Box_Red"};
+    respawnMagazines[] = {"tacgt_200Rnd_556x45_M855A1_Box_Red"};
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Tanoan_Autorifleman.jpg);
 };
 
@@ -203,8 +203,8 @@ class TACU_Revolutionaries_U_O_Tanoan_Leader: TACU_Revolutionaries_U_O_Tanoan_Ri
     respawnLinkedItems[] = {DEFAULT_ITEMS, "V_LegStrapBag_black_F", "H_Booniehat_oil", "G_Balaclava_blk"};
     weapons[] = {"TACU_Revolutionaries_W_CZ805_GL", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Revolutionaries_W_CZ805_GL", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_G36"), mag_6("1Rnd_HE_Grenade_shell")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_G36"), mag_6("1Rnd_HE_Grenade_shell")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_G36"), mag_6("1Rnd_HE_Grenade_shell")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_G36"), mag_6("1Rnd_HE_Grenade_shell")};
     editorPreview = QPATHTOF(ui\Revolutionaries_U_O_Tanoan_Leader.jpg);
     headgearList[] = {
         "H_Booniehat_oil", 1

--- a/addons/revolutionaries/CfgWeapons.hpp
+++ b/addons/revolutionaries/CfgWeapons.hpp
@@ -11,7 +11,7 @@ class CfgWeapons {
             };
         };
     };
-    
+
     class LMG_03_F;
     class TACU_Revolutionaries_W_FNMinimiSPW: LMG_03_F {
         dlc = QUOTE(PREFIX);
@@ -31,7 +31,7 @@ class CfgWeapons {
             EQUIP_POINTER(acc_flashlight);
         };
     };
-    
+
     class CUP_arifle_CZ805_GL;
     class TACU_Revolutionaries_W_CZ805_GL: CUP_arifle_CZ805_GL {
         dlc = QUOTE(PREFIX);
@@ -42,6 +42,6 @@ class CfgWeapons {
                 slot = "CUP_PicatinnySideMountCZ805";
                 item = "acc_flashlight";
             };
-        };    
+        };
     };
 };

--- a/addons/takistan/CfgFactionClasses.hpp
+++ b/addons/takistan/CfgFactionClasses.hpp
@@ -10,7 +10,7 @@ class CfgFactionClasses {
         side = 2;
         priority = 4;
     };
-    
+
     class TACU_Takistan_Tehrik {
         displayName = "Tehrik-I-Taliban Takistan";
         side = 0;

--- a/addons/takistan/CfgGroups_TNA.hpp
+++ b/addons/takistan/CfgGroups_TNA.hpp
@@ -2,7 +2,7 @@ class TACU_Takistan_TNA {
     name = "Takistan National Army";
     class TACU_Takistan_G_TNA_Regular_Infantry {
         name = "Men (Regular)";
-        
+
         class TACU_Takistan_G_TNA_Regular_Patrol {
             name = "Patrol";
             side = 2;
@@ -52,7 +52,7 @@ class TACU_Takistan_TNA {
                 position[] = {10, -10, 0};
             };
         };
-        
+
         class TACU_Takistan_G_TNA_Regular_Squad {
             name = "Squad";
             side = 2;
@@ -96,7 +96,7 @@ class TACU_Takistan_TNA {
             };
         };
     };
-    
+
     class TACU_Takistan_G_TNA_Commandos_Infantry {
         name = "Men (Commandos)";
 

--- a/addons/takistan/CfgVehicles_TNA.hpp
+++ b/addons/takistan/CfgVehicles_TNA.hpp
@@ -31,8 +31,8 @@ class TACU_Takistan_U_TNA_Lieutenant: TACU_Takistan_U_TNA_Major {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_B_RRV_TL", "CUP_H_TK_Beret"};
     weapons[] = {"CUP_arifle_M16A2", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_M16A2", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("CUP_15Rnd_9x19_M9")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("CUP_15Rnd_9x19_M9")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9")};
 };
 
 class TACU_Takistan_U_TNA_NCO: TACU_Takistan_U_TNA_Lieutenant {
@@ -42,8 +42,8 @@ class TACU_Takistan_U_TNA_NCO: TACU_Takistan_U_TNA_Lieutenant {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_B_PASGT_no_bags_OD", "CUP_H_Ger_M92_RGR"};
     weapons[] = {"CUP_arifle_M16A2", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_M16A2", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("CUP_15Rnd_9x19_M9"), mag_2("SmokeShell")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("CUP_15Rnd_9x19_M9"), mag_2("SmokeShell")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9"), mag_2("SmokeShell")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9"), mag_2("SmokeShell")};
     editorSubcategory = "TACU_Takistan_EdSubCat_Regular";
 };
 
@@ -52,8 +52,8 @@ class TACU_Takistan_U_TNA_Rifleman: TACU_Takistan_U_TNA_NCO {
     editorPreview = QPATHTOF(ui\Takistan_U_TNA_Rifleman.jpg);
     weapons[] = {"CUP_arifle_M16A2", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_M16A2", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("SmokeShell")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("SmokeShell")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("SmokeShell")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("SmokeShell")};
 };
 
 class TACU_Takistan_U_TNA_Rifleman_02: TACU_Takistan_U_TNA_Rifleman {
@@ -101,8 +101,8 @@ class TACU_Takistan_U_TNA_Commandos_NCO: TACU_Takistan_U_TNA_Major {
     backpack = "CUP_B_Kombat_Radio_Olive";
     weapons[] = {"TACU_Takistan_W_M4A3_Desert", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Takistan_W_M4A3_Desert", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("ACE_M84"), mag_4("SmokeShell")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("ACE_M84"), mag_4("SmokeShell")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("ACE_M84"), mag_4("SmokeShell")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("ACE_M84"), mag_4("SmokeShell")};
     editorSubcategory = "TACU_Takistan_EdSubCat_Commandos";
 };
 
@@ -113,8 +113,8 @@ class TACU_Takistan_U_TNA_Commandos_Breacher: TACU_Takistan_U_TNA_Commandos_NCO 
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_B_Ciras_Olive2", "CUP_H_OpsCore_Grey", "CUP_NVG_PVS15_black"};
     weapons[] = {"CUP_sgun_M1014_solidstock", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"CUP_sgun_M1014_solidstock", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_8Rnd_B_Beneli_74Pellets"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("ACE_M84"), mag_4("SmokeShell")};
-    respawnMagazines[] = {mag_6("CUP_8Rnd_B_Beneli_74Pellets"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("ACE_M84"), mag_4("SmokeShell")};
+    magazines[] = {mag_6("tacgt_8Rnd_P_000"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("ACE_M84"), mag_4("SmokeShell")};
+    respawnMagazines[] = {mag_6("tacgt_8Rnd_P_000"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("ACE_M84"), mag_4("SmokeShell")};
 };
 
 class TACU_Takistan_U_TNA_Commandos_Grenadier: TACU_Takistan_U_TNA_Commandos_NCO {
@@ -125,8 +125,8 @@ class TACU_Takistan_U_TNA_Commandos_Grenadier: TACU_Takistan_U_TNA_Commandos_NCO
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_PMC_CIRAS_Coyote_Grenadier", "CUP_H_OpsCore_Tan", "CUP_NVG_PVS15_black"};
     weapons[] = {"TACU_Takistan_W_M4A1_GL"};
     respawnWeapons[] = {"TACU_Takistan_W_M4A1_GL"};
-    magazines[] = {mag_6("CUP_1Rnd_HEDP_M203"), mag_8("CUP_30Rnd_556x45_Stanag")};
-    respawnMagazines[] = {mag_6("CUP_1Rnd_HEDP_M203"), mag_8("CUP_30Rnd_556x45_Stanag")};
+    magazines[] = {mag_6("CUP_1Rnd_HEDP_M203"), mag_8("tacgt_30Rnd_556x45_M855A1_EMAG")};
+    respawnMagazines[] = {mag_6("CUP_1Rnd_HEDP_M203"), mag_8("tacgt_30Rnd_556x45_M855A1_EMAG")};
 };
 
 class TACU_Takistan_U_TNA_Commandos_Autorifleman: TACU_Takistan_U_TNA_Commandos_NCO {
@@ -135,10 +135,10 @@ class TACU_Takistan_U_TNA_Commandos_Autorifleman: TACU_Takistan_U_TNA_Commandos_
     backpack = "TACU_Takistan_B_TNA_LMG";
     weapons[] = {"CUP_lmg_m249_para", "Throw", "Put"};
     respawnWeapons[] = {"CUP_lmg_m249_para", "Throw", "Put"};
-    magazines[] = {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", mag_3("HandGrenade"), mag_2("SmokeShell")};
-    respawnMagazines[] = {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", mag_3("HandGrenade"), mag_2("SmokeShell")};
+    magazines[] = {"CUP_200Rnd_TE4_Red_Tracer_556x45_L110A1", mag_3("HandGrenade"), mag_2("SmokeShell")};
+    respawnMagazines[] = {"CUP_200Rnd_TE4_Red_Tracer_556x45_L110A1", mag_3("HandGrenade"), mag_2("SmokeShell")};
 };
-    
+
  class TACU_Takistan_U_TNA_Commandos_Medic: TACU_Takistan_U_TNA_Commandos_NCO {
     displayName = "Medic";
     editorPreview = QPATHTOF(ui\Takistan_U_TNA_Commandos_Medic.jpg);
@@ -148,8 +148,8 @@ class TACU_Takistan_U_TNA_Commandos_Autorifleman: TACU_Takistan_U_TNA_Commandos_
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_B_Ciras_Olive4", "CUP_H_OpsCore_Spray", "CUP_NVG_PVS15_black"};
     weapons[] = {"TACU_Takistan_W_M4A3", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Takistan_W_M4A3", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("SmokeShell")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("SmokeShell")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("SmokeShell")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("SmokeShell")};
 };
 
 class TACU_Takistan_U_TNA_Commandos_Rifleman_AT: TACU_Takistan_U_TNA_Commandos_NCO {
@@ -160,8 +160,8 @@ class TACU_Takistan_U_TNA_Commandos_Rifleman_AT: TACU_Takistan_U_TNA_Commandos_N
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_B_Ciras_Olive", "CUP_H_OpsCore_Spray", "CUP_NVG_PVS15_black"};
     weapons[] = {"TACU_Takistan_W_M4A1", "CUP_hgun_M9", "CUP_launch_M136_Loaded", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Takistan_W_M4A1", "CUP_hgun_M9", "CUP_launch_M136_Loaded", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("SmokeShell")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("SmokeShell")};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("SmokeShell")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("HandGrenade"), mag_2("SmokeShell")};
 };
 
 // Vehicles - TNA

--- a/addons/takistan/CfgVehicles_TNP.hpp
+++ b/addons/takistan/CfgVehicles_TNP.hpp
@@ -12,8 +12,8 @@ class TACU_Takistan_U_TNP_Officer: TACU_Main_U_INDEP_Soldier_Base {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket1_03", "CUP_H_TKI_Pakol_2_02"};
     weapons[] = {"CUP_arifle_AKMS_Early", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKMS_Early", "Throw", "Put"};
-    magazines[] = {mag_4("CUP_30Rnd_762x39_AK47_M")};
-    respawnMagazines[] = {mag_4("CUP_30Rnd_762x39_AK47_M")};
+    magazines[] = {mag_4("tacgt_30Rnd_762x39_BP_Mag")};
+    respawnMagazines[] = {mag_4("tacgt_30Rnd_762x39_BP_Mag")};
     editorSubcategory = "TACU_Takistan_EdSubCat_Officer";
     headgearList[] = {
         "CUP_H_TKI_SkullCap_05", 0.20,
@@ -31,8 +31,8 @@ class TACU_Takistan_U_TNP_Rifleman: TACU_Takistan_U_TNP_Officer {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket2_06", "CUP_H_TKI_SkullCap_02"};
     weapons[] = {"CUP_arifle_AKS74_Early", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKS74_Early", "Throw", "Put"};
-    magazines[] = {mag_7("CUP_30Rnd_545x39_AK74M_M")};
-    respawnMagazines[] = {mag_7("CUP_30Rnd_545x39_AK74M_M")};
+    magazines[] = {mag_7("tacgt_30Rnd_545x39_BT_Mag_Bakelite")};
+    respawnMagazines[] = {mag_7("tacgt_30Rnd_545x39_BT_Mag_Bakelite")};
 };
 
 class TACU_Takistan_U_TNP_Rifleman_02: TACU_Takistan_U_TNP_Rifleman {
@@ -42,8 +42,8 @@ class TACU_Takistan_U_TNP_Rifleman_02: TACU_Takistan_U_TNP_Rifleman {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket2_01", "CUP_H_TKI_Pakol_1_01"};
     weapons[] = {"CUP_arifle_AKS74", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKS74", "Throw", "Put"};
-    magazines[] = {mag_7("CUP_30Rnd_545x39_AK_M")};
-    respawnMagazines[] = {mag_7("CUP_30Rnd_545x39_AK_M")};
+    magazines[] = {mag_7("tacgt_30Rnd_545x39_BT_Mag_Bakelite")};
+    respawnMagazines[] = {mag_7("tacgt_30Rnd_545x39_BT_Mag_Bakelite")};
 };
 
 class TACU_Takistan_U_TNP_Autorifleman: TACU_Takistan_U_TNP_Rifleman_02 {
@@ -53,8 +53,8 @@ class TACU_Takistan_U_TNP_Autorifleman: TACU_Takistan_U_TNP_Rifleman_02 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket4_04", "CUP_H_TKI_SkullCap_05"};
     weapons[] = {"CUP_arifle_RPK74", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_RPK74", "Throw", "Put"};
-    magazines[] = {mag_4("CUP_30Rnd_762x39_AK47_TK_M")};
-    respawnMagazines[] = {mag_4("CUP_30Rnd_762x39_AK47_TK_M")};
+    magazines[] = {mag_4("tacgt_75Rnd_762x39_RPK_BP_Mag")};
+    respawnMagazines[] = {mag_4("tacgt_75Rnd_762x39_RPK_BP_Mag")};
 };
 
 // Vehicles - TNP

--- a/addons/takistan/CfgVehicles_TSF.hpp
+++ b/addons/takistan/CfgVehicles_TSF.hpp
@@ -21,8 +21,8 @@ class TACU_Takistan_U_TSF_Rifleman_01: TACU_Main_U_BLUFOR_Soldier_Base {
     respawnItems[] = {mag_6("ACE_fieldDressing")};
     weapons[] = {"TACU_Takistan_W_M4SBR_Tan", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Takistan_W_M4SBR_Tan", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_Emag"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_Emag"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
     headgearList[] = {
         "CUP_H_TKI_Lungee_Open_01", 1,
         "CUP_H_TKI_Lungee_Open_02", 1,
@@ -50,8 +50,8 @@ class TACU_Takistan_U_TSF_Rifleman_02: TACU_Takistan_U_TSF_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_H_TKI_Lungee_Open_01", "CUP_V_OI_TKI_Jacket4_03"};
     weapons[] = {"TACU_Takistan_W_M4A3", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Takistan_W_M4A3", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_Emag"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_Emag"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
 };
 
 class TACU_Takistan_U_TSF_Rifleman_03: TACU_Takistan_U_TSF_Rifleman_01 {
@@ -62,8 +62,8 @@ class TACU_Takistan_U_TSF_Rifleman_03: TACU_Takistan_U_TSF_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_H_TK_Lungee", "CUP_FR_NeckScarf", "CUP_V_B_BAF_DDPM_Osprey_Mk3_Rifleman"};
     weapons[] = {"TACU_Takistan_W_M16A4", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Takistan_W_M16A4", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_556x45_Stanag"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
+    magazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_3("CUP_15Rnd_9x19_M9"), "HandGrenade", "SmokeShell"};
     headgearList[] = {
         "CUP_H_TK_Lungee", 1,
         "CUP_H_TKI_Lungee_Open_01", 1,
@@ -94,8 +94,8 @@ class TACU_Takistan_U_TSF_Grenadier: TACU_Takistan_U_TSF_Rifleman_01 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_H_TKI_Lungee_Open_01", "CUP_V_OI_TKI_Jacket1_01"};
     weapons[] = {"TACU_Takistan_W_M4A1_GL", "CUP_hgun_M9", "Throw", "Put"};
     respawnWeapons[] = {"TACU_Takistan_W_M4A1_GL", "CUP_hgun_M9", "Throw", "Put"};
-    magazines[] = {mag_5("CUP_30Rnd_556x45_Emag"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("1Rnd_HE_Grenade_shell")};
-    respawnMagazines[] = {mag_5("CUP_30Rnd_556x45_Emag"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("1Rnd_HE_Grenade_shell")};
+    magazines[] = {mag_5("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("1Rnd_HE_Grenade_shell")};
+    respawnMagazines[] = {mag_5("tacgt_30Rnd_556x45_M855A1_EMAG"), mag_2("CUP_15Rnd_9x19_M9"), mag_3("1Rnd_HE_Grenade_shell")};
 };
 
 class TACU_Takistan_U_TSF_Sniper: TACU_Takistan_U_TSF_Rifleman_01 {

--- a/addons/takistan/CfgVehicles_Tehrik.hpp
+++ b/addons/takistan/CfgVehicles_Tehrik.hpp
@@ -16,8 +16,8 @@ class TACU_Takistan_U_Tehrik_Leader: TACU_Main_U_OPFOR_Soldier_Base {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket2_06", "CUP_H_TK_Lungee"};
     weapons[] = {"CUP_arifle_AK47", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AK47", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_762x39_AK47_M"), mag_5("CUP_HandGrenade_RGD5")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_762x39_AK47_M"), mag_5("CUP_HandGrenade_RGD5")};
+    magazines[] = {mag_6("tacgt_30Rnd_762x39_BP_Mag"), mag_5("CUP_HandGrenade_RGD5")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_762x39_BP_Mag"), mag_5("CUP_HandGrenade_RGD5")};
     editorSubcategory = "TACU_Takistan_EdSubCat_Veteran";
 };
 
@@ -28,8 +28,8 @@ class TACU_Takistan_U_Tehrik_Rifleman: TACU_Takistan_U_Tehrik_Leader {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket4_05", "CUP_H_TKI_Lungee_05"};
     weapons[] = {"CUP_arifle_AK47", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AK47", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_762x39_AK47_M"), mag_5("CUP_HandGrenade_RGD5")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_762x39_AK47_M"), mag_5("CUP_HandGrenade_RGD5")};
+    magazines[] = {mag_6("tacgt_30Rnd_762x39_BP_Mag"), mag_5("CUP_HandGrenade_RGD5")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_762x39_BP_Mag"), mag_5("CUP_HandGrenade_RGD5")};
 };
 
 class TACU_Takistan_U_Tehrik_Rifleman_02: TACU_Takistan_U_Tehrik_Rifleman {
@@ -39,8 +39,8 @@ class TACU_Takistan_U_Tehrik_Rifleman_02: TACU_Takistan_U_Tehrik_Rifleman {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket2_03", "CUP_H_TKI_Lungee_03"};
     weapons[] = {"CUP_arifle_AKMS", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKMS", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_762x39_AK47_bakelite_M"), mag_5("CUP_HandGrenade_RGD5")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_762x39_AK47_bakelite_M"), mag_5("CUP_HandGrenade_RGD5")};
+    magazines[] = {mag_6("tacgt_30Rnd_762x39_BP_Mag"), mag_5("CUP_HandGrenade_RGD5")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_762x39_BP_Mag"), mag_5("CUP_HandGrenade_RGD5")};
 };
 
 class TACU_Takistan_U_Tehrik_Grenadier: TACU_Takistan_U_Tehrik_Rifleman_02 {
@@ -50,8 +50,8 @@ class TACU_Takistan_U_Tehrik_Grenadier: TACU_Takistan_U_Tehrik_Rifleman_02 {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket2_01", "CUP_H_TKI_Lungee_06"};
     weapons[] = {"CUP_arifle_AKM_GL_Early", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKM_GL_Early", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_762x39_AK47_bakelite_M"), mag_10("CUP_1Rnd_HE_GP25_M")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_762x39_AK47_bakelite_M"), mag_10("CUP_1Rnd_HE_GP25_M")};
+    magazines[] = {mag_6("tacgt_30Rnd_762x39_BP_Mag"), mag_10("CUP_1Rnd_HE_GP25_M")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_762x39_BP_Mag"), mag_10("CUP_1Rnd_HE_GP25_M")};
 };
 
 class TACU_Takistan_U_Tehrik_Autorifleman: TACU_Takistan_U_Tehrik_Grenadier {
@@ -74,8 +74,8 @@ class TACU_Takistan_U_Tehrik_Rifleman_AT: TACU_Takistan_U_Tehrik_Grenadier {
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket3_02", "CUP_H_TKI_Lungee_03"};
     weapons[] = {"CUP_arifle_AKS", "CUP_launch_RPG7V", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKS", "CUP_launch_RPG7V", "Throw", "Put"};
-    magazines[] = {mag_5("CUP_30Rnd_762x39_AK47_M"), "RPG7_F"};
-    respawnMagazines[] = {mag_5("CUP_30Rnd_762x39_AK47_M"), "RPG7_F"};
+    magazines[] = {mag_5("tacgt_30Rnd_762x39_BP_Mag"), "RPG7_F"};
+    respawnMagazines[] = {mag_5("tacgt_30Rnd_762x39_BP_Mag"), "RPG7_F"};
 };
 
 // Units - Tehrik-i-Taliban Takistan, Enlisted.
@@ -86,8 +86,8 @@ class TACU_Takistan_U_Tehrik_Enlisted_Squadleader: TACU_Takistan_U_Tehrik_Leader
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket4_03", "CUP_H_TKI_Lungee_Open_01"};
     weapons[] = {"CUP_arifle_AKS74U", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKS74U", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_545x39_AK74_plum_M")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_545x39_AK74_plum_M")};
+    magazines[] = {mag_6("tacgt_30Rnd_545x39_BT_Mag_Plum")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_545x39_BT_Mag_Plum")};
     editorSubcategory = "TACU_Takistan_EdSubCat_Enlisted";
 };
 
@@ -99,8 +99,8 @@ class TACU_Takistan_U_Tehrik_Enlisted_Rifleman: TACU_Takistan_U_Tehrik_Enlisted_
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket5_05", "CUP_H_TKI_SkullCap_04"};
     weapons[] = {"CUP_arifle_AK74_Early", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AK74_Early", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_545x39_AK_M")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_545x39_AK_M")};
+    magazines[] = {mag_6("tacgt_30Rnd_545x39_BT_Mag_Black")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_545x39_BT_Mag_Black")};
 };
 
 class TACU_Takistan_U_Tehrik_Enlisted_Rifleman_02: TACU_Takistan_U_Tehrik_Enlisted_Rifleman {
@@ -111,8 +111,8 @@ class TACU_Takistan_U_Tehrik_Enlisted_Rifleman_02: TACU_Takistan_U_Tehrik_Enlist
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket1_04", "CUP_H_TKI_Pakol_1_06"};
     weapons[] = {"CUP_arifle_AKMS", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKMS", "Throw", "Put"};
-    magazines[] = {mag_6("CUP_30Rnd_762x39_AK47_bakelite_M")};
-    respawnMagazines[] = {mag_6("CUP_30Rnd_762x39_AK47_bakelite_M")};
+    magazines[] = {mag_6("tacgt_30Rnd_762x39_BP_Mag")};
+    respawnMagazines[] = {mag_6("tacgt_30Rnd_762x39_BP_Mag")};
 };
 
 class TACU_Takistan_U_Tehrik_Enlisted_Rifleman_03: TACU_Takistan_U_Tehrik_Enlisted_Rifleman_02 {
@@ -139,8 +139,8 @@ class TACU_Takistan_U_Tehrik_Enlisted_Autorifleman: TACU_Takistan_U_Tehrik_Enlis
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket4_06", "CUP_H_TKI_Lungee_06"};
     weapons[] = {"CUP_arifle_RPK74", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_RPK74", "Throw", "Put"};
-    magazines[] = {mag_3("CUP_75Rnd_TE4_LRT4_Green_Tracer_762x39_RPK_M")};
-    respawnMagazines[] = {mag_3("CUP_75Rnd_TE4_LRT4_Green_Tracer_762x39_RPK_M")};
+    magazines[] = {mag_3("tacgt_75Rnd_762x39_RPK_BP_Mag")};
+    respawnMagazines[] = {mag_3("tacgt_75Rnd_762x39_RPK_BP_Mag")};
 };
 
 class TACU_Takistan_U_Tehrik_Enlisted_Rifleman_AT: TACU_Takistan_U_Tehrik_Rifleman_AT {
@@ -151,8 +151,8 @@ class TACU_Takistan_U_Tehrik_Enlisted_Rifleman_AT: TACU_Takistan_U_Tehrik_Riflem
     respawnLinkedItems[] = {DEFAULT_ITEMS_RADIO, "CUP_V_OI_TKI_Jacket2_04", "CUP_H_TKI_Lungee_04"};
     weapons[] = {"CUP_arifle_AKS74U", "CUP_launch_RPG7V", "Throw", "Put"};
     respawnWeapons[] = {"CUP_arifle_AKS74U", "CUP_launch_RPG7V", "Throw", "Put"};
-    magazines[] = {mag_5("CUP_30Rnd_545x39_AK74_plum_M"), "RPG7_F"};
-    respawnMagazines[] = {mag_5("CUP_30Rnd_545x39_AK74_plum_M"), "RPG7_F"};
+    magazines[] = {mag_5("tacgt_30Rnd_545x39_BT_Mag_Plum"), "RPG7_F"};
+    respawnMagazines[] = {mag_5("tacgt_30Rnd_545x39_BT_Mag_Plum"), "RPG7_F"};
     editorSubcategory = "TACU_Takistan_EdSubCat_Enlisted";
 };
 


### PR DESCRIPTION
- Switches out generic CUP/Vanilla ammunition for improved GT Armory ammunitions where available.
- Closes #40 
- Removes some excess whitespace.

Relies on this [PR](https://github.com/Theseus-Aegis/GTArmory/pull/37) from GT Armory