### PR TITLE
Remove WS African identities from African Factions

### DIFF
--- a/addons/african_north/CfgVehicles_B.hpp
+++ b/addons/african_north/CfgVehicles_B.hpp
@@ -5,7 +5,7 @@ class TACU_African_North_U_B_Rifleman: TACU_Main_U_BLUFOR_Soldier_Base {
     faction = "TACU_African_North_B";
     scope = 2;
     scopeCurator = 2;
-    identityTypes[] = {"LanguageFRE_F", "Head_African", "lxWS_Head_African"};
+    identityTypes[] = {"LanguageFRE_F", "Head_African", "Head_Tanoan"};
     genericNames = "TACU_AfricanNames";
     icon = "iconMan";
     role = "Rifleman";

--- a/addons/somali_pirates/CfgVehicles_I.hpp
+++ b/addons/somali_pirates/CfgVehicles_I.hpp
@@ -4,7 +4,7 @@ class TACU_Somali_Pirates_U_I_Rifleman_01: TACU_Main_U_INDEP_Soldier_Base {
     faction = "TACU_Somali_I";
     scope = 2;
     scopeCurator = 2;
-    identityTypes[] = {"LanguageFRE_F", "Head_African", "lxWS_Head_African"};
+    identityTypes[] = {"LanguageFRE_F", "Head_African", "Head_Tanoan"};
     genericNames = "TACU_SomaliNames";
     icon = "iconMan";
     role = "Rifleman";


### PR DESCRIPTION
- WS Africans use Middle eastern heads too. Doesn't work for Africans.