### PR TITLE
Africans - Make Generic & Cleanup

### DIFF
--- a/addons/african_militia/CfgFactionClasses.hpp
+++ b/addons/african_militia/CfgFactionClasses.hpp
@@ -1,6 +1,6 @@
 class CfgFactionClasses {
     class TACU_African_Militia_O {
-        displayName = "Pride of Africa";
+        displayName = "African Militia";
         side = 0;
         priority = 1;
     };

--- a/addons/african_militia/CfgGroups.hpp
+++ b/addons/african_militia/CfgGroups.hpp
@@ -1,13 +1,13 @@
 class CfgGroups {
     class EAST {
         class TACU_African_Militia_O {
-            name = "Pride of Africa";
+            name = "African Militia";
             #include "CfgGroups_O.hpp"
         };
     };
     class INDEP {
         class TACU_African_Militia_I {
-            name = "Pride of Africa";
+            name = "African Militia";
             #include "CfgGroups_I.hpp"
         };
     };

--- a/addons/african_north/CfgFactionClasses.hpp
+++ b/addons/african_north/CfgFactionClasses.hpp
@@ -1,6 +1,6 @@
 class CfgFactionClasses {
     class TACU_African_North_B {
-        displayName = "Army of the African Republic";
+        displayName = "Northern Africa";
         side = 1;
         priority = 1;
     };

--- a/addons/african_north/CfgGroups_B.hpp
+++ b/addons/african_north/CfgGroups_B.hpp
@@ -1,5 +1,5 @@
 class TACU_African_North_B {
-    name = "Army of the African Republic";
+    name = "Northern Africa";
 
     class TACU_African_North_Infantry {
         name = "Infantry";

--- a/addons/african_north/CfgGroups_I.hpp
+++ b/addons/african_north/CfgGroups_I.hpp
@@ -1,5 +1,5 @@
 class TACU_African_North_I {
-    name = "Army of the African Republic";
+    name = "Northern Africa";
 
     class TACU_African_North_Infantry_I {
         name = "Infantry";
@@ -7,7 +7,7 @@ class TACU_African_North_I {
         class TACU_African_North_G_Patrol {
             name = "Patrol";
             side = 2;
-            faction = "TACU_African_North_B";
+            faction = "TACU_African_North_I";
             icon = "\a3\ui_f\data\map\markers\nato\n_inf.paa";
             MACRO_UNIT0(TACU_African_North_U_I_Teamleader,2);
             MACRO_UNIT1(TACU_African_North_U_I_Rifleman,2);

--- a/addons/african_north/CfgGroups_O.hpp
+++ b/addons/african_north/CfgGroups_O.hpp
@@ -1,5 +1,5 @@
 class TACU_African_North_O {
-    name = "Army of the African Republic";
+    name = "Northern Africa";
 
     class TACU_African_North_Infantry_O {
         name = "Infantry";

--- a/addons/african_south/CfgFactionClasses.hpp
+++ b/addons/african_south/CfgFactionClasses.hpp
@@ -1,6 +1,6 @@
 class CfgFactionClasses {
     class TACU_African_South_B {
-        displayName = "South Africa";
+        displayName = "Southern Africa";
         side = 1;
         priority = 1;
     };

--- a/addons/african_south/CfgGroups_B.hpp
+++ b/addons/african_south/CfgGroups_B.hpp
@@ -1,5 +1,5 @@
 class TACU_African_South_B {
-    name = "South Africa";
+    name = "Southern Africa";
 
     class TACU_African_South_Infantry_B {
         name = "Infantry";
@@ -7,7 +7,7 @@ class TACU_African_South_B {
         class TACU_African_South_G_Patrol {
             name = "Patrol";
             side = 1;
-            faction = "TACU_African_North_B";
+            faction = "TACU_African_South_B";
             icon = "\a3\ui_f\data\map\markers\nato\n_inf.paa";
             MACRO_UNIT0(TACU_African_South_U_B_Rifleman,1);
             MACRO_UNIT1(TACU_African_South_U_B_CQB,1);

--- a/addons/african_south/CfgGroups_I.hpp
+++ b/addons/african_south/CfgGroups_I.hpp
@@ -1,5 +1,5 @@
 class TACU_African_South_I {
-    name = "South Africa";
+    name = "Southern Africa";
 
     class TACU_African_South_Infantry_I {
         name = "Infantry";
@@ -7,7 +7,7 @@ class TACU_African_South_I {
         class TACU_African_South_G_Patrol {
             name = "Patrol";
             side = 2;
-            faction = "TACU_African_North_I";
+            faction = "TACU_African_South_I";
             icon = "\a3\ui_f\data\map\markers\nato\n_inf.paa";
             MACRO_UNIT0(TACU_African_South_U_I_Rifleman,2);
             MACRO_UNIT1(TACU_African_South_U_I_CQB,2);

--- a/addons/african_south/CfgGroups_O.hpp
+++ b/addons/african_south/CfgGroups_O.hpp
@@ -1,5 +1,5 @@
 class TACU_African_South_O {
-    name = "South Africa";
+    name = "Southern Africa";
 
     class TACU_African_South_Infantry_O {
         name = "Infantry";
@@ -7,7 +7,7 @@ class TACU_African_South_O {
         class TACU_African_South_G_Patrol {
             name = "Patrol";
             side = 0;
-            faction = "TACU_African_North_O";
+            faction = "TACU_African_South_O";
             icon = "\a3\ui_f\data\map\markers\nato\n_inf.paa";
             MACRO_UNIT0(TACU_African_South_U_O_Rifleman,0);
             MACRO_UNIT1(TACU_African_South_U_O_CQB,0);


### PR DESCRIPTION
Mick pointed out more generic names for these factions is preferable to super specific, leaving it open to the mission maker for naming if desired.

- African Militia; Now known as "African Militia" (Formerly: Pride of Africa)
- South Africa; Now known as "Southern Africa" (Formerly: South Africa)
- North Africa: Now known as "Northern Africa" (Formerly: Army of the African Republic)
- Fixed wrong group factions