### PR TITLE
Ammunition - Set balanced mass values & Alter launcher ammo

### DIFF
--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -190,4 +190,73 @@ class CfgAmmo {
         caliber = 2.1;
         hit = 14.5;
     };
+
+    // RPG Ammo
+    class RocketBase;
+
+    // PG-7VM HEAT Grenade
+    class R_PG7_F: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+    // RPG-42 Rocket
+    class R_PG32V_F: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // RPG-42 HE Rocket
+    class R_TBG32V_F: R_PG32V_F {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // MAAWS HEAT 75 Round
+    class R_MRAAWS_HEAT_F: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // MAAWS HEAT 55 Round
+    class R_MRAAWS_HEAT55_F: R_MRAAWS_HEAT_F {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // MAAWS HE 44 Round
+    class R_MRAAWS_HE_F: R_MRAAWS_HEAT_F {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+        ace_frag_classes[] = {"ACE_frag_medium"};
+    };
+
+    // SPG-9 HEAT
+    class M_SPG9_HEAT: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // SPG-9 HE
+    class M_SPG9_HE: M_SPG9_HEAT {
+        ace_frag_enabled = 1;
+        ace_frag_metal = 350;
+        ace_frag_charge = 210;
+        ace_frag_gurney_c = 2800;
+        ace_Frag_gurney_k = "3/5";
+        ace_frag_classes[] = {"ACE_frag_medium"};
+    };
 };

--- a/addons/ammunition/CfgMagazines.hpp
+++ b/addons/ammunition/CfgMagazines.hpp
@@ -49,6 +49,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_9x19";
         displayName = "Generic 30Rnd 9mm SMG Magazine";
+        mass = 8;
     };
 
     class 30Rnd_9x21_Mag_SMG_02;
@@ -56,6 +57,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_9x19";
         displayName = "Generic 30Rnd 9mm SMG Magazine";
+        mass = 8;
     };
 
     class 30Rnd_45ACP_Mag_SMG_01;
@@ -63,6 +65,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_45ACP";
         displayName = "Generic 25Rnd Vector Magazine";
+        mass = 8;
     };
 
     class 50Rnd_570x28_SMG_03;
@@ -70,6 +73,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_58x52";
         displayName = "Generic 50Rnd P90 Magazine";
+        mass = 8;
     };
 
     // Assault Rifles
@@ -78,6 +82,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_545x39";
         displayName = "Generic 30Rnd 5.45 AK Magazine";
+        mass = 9;
     };
 
     class 30Rnd_556x45_Stanag;
@@ -85,6 +90,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 30Rnd STANAG Magazine";
+        mass = 9;
     };
 
     class 35Rnd_556x45_Velko_reload_tracer_red_lxWS;
@@ -92,6 +98,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 35Rnd Velko Magazine";
+        mass = 10;
     };
 
     class 30Rnd_580x42_Mag_F;
@@ -99,6 +106,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_58x52";
         displayName = "Generic 30Rnd QBZ Magazine";
+        mass = 9;
     };
 
     // Katiba
@@ -107,6 +115,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_65x39";
         displayName = "Generic 30Rnd Katiba Magazine";
+        mass = 9;
     };
 
     // MX
@@ -115,6 +124,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_65x39";
         displayName = "Generic 30Rnd MX Magazine";
+        mass = 9;
     };
 
     // Promet / MSBS
@@ -123,6 +133,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_65x39";
         displayName = "Generic 30Rnd MSBS Magazine";
+        mass = 9;
     };
 
     class 30Rnd_762x39_Mag_F;
@@ -130,6 +141,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_762x39";
         displayName = "Generic 30Rnd 7.62 AK Magazine";
+        mass = 10;
     };
 
     // Battle Rifles / Marksman Rifles
@@ -153,6 +165,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_762x51";
         displayName = "Generic 20Rnd M1A Magazine";
+        mass = 10;
     };
 
     class 10Rnd_762x54_Mag;
@@ -167,6 +180,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_762x51";
         displayName = "Generic 20Rnd SLR Magazine";
+        mass = 10;
     };
 
     // Machine Guns
@@ -175,6 +189,7 @@ class CfgMagazines {
         MACRO_MG_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 75Rnd 5.56 Surefire Magazine";
+        mass = 15;
     };
 
     class 150Rnd_556x45_Drum_Mag_F;
@@ -217,6 +232,7 @@ class CfgMagazines {
         MACRO_MG_MAGAZINE;
         ammo = "TACU_Ammunition_762x39";
         displayName = "Generic 75Rnd AK Drum Magazine";
+        mass = 25;
     };
 
     class 150Rnd_762x51_Box;

--- a/addons/ammunition/CfgWeapons.hpp
+++ b/addons/ammunition/CfgWeapons.hpp
@@ -1,8 +1,10 @@
 class CfgWeapons {
     /*
-     * Here only to add Magwells to guns missing them.
+     * Adds missing magwells to weapons that lack them.
+     * Alters RPG firemodes.
     */
 
+    // Magwells
     class Pistol_Base_F;
     class hgun_Pistol_01_F: Pistol_Base_F {
         magazineWell[] += {"CBA_9x18_PM"};
@@ -44,5 +46,21 @@ class CfgWeapons {
     class arifle_Galat_base_lxWS;
     class arifle_Galat_lxWS: arifle_Galat_base_lxWS {
         magazineWell[] += {"CBA_762x39_AK"};
+    };
+
+    // RPG firemodes
+    class Launcher_Base_F;
+    class launch_RPG7_F: Launcher_Base_F {
+        class Single: Mode_SemiAuto {
+            minRange = 50;
+            minRangeProbab = 0.50;
+            midRange = 500;
+            midRangeProbab = 0.40;
+            maxRange = 800;
+            maxRangeProbab = 0.30;
+            aiRateOfFire = 7;
+            aiRateOfFireDistance = 250;
+            aiRateOfFireDispersion = 7;
+        };
     };
 };

--- a/addons/ammunition/subconfig_CUP/CfgAmmo.hpp
+++ b/addons/ammunition/subconfig_CUP/CfgAmmo.hpp
@@ -31,4 +31,77 @@ class CfgAmmo {
         visibleFire = 0.07;
         visibleFireTime = 2;
     };
+
+    // RPG Ammo
+    class RocketBase;
+
+    // OG-7V (Frag) Rocket
+    class CUP_R_OG7_AT: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+        ace_frag_enabled = 1;
+        ace_frag_metal = 350;
+        ace_frag_charge = 210;
+        ace_frag_gurney_c = 2800;
+        ace_Frag_gurney_k = "3/5";
+        ace_frag_classes[] = {"ACE_frag_medium"};
+    };
+
+    // PG-7V (HEAT) Rocket
+    class CUP_R_PG7V_AT: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // PG-7VL (HEAT) Rocket
+    class CUP_R_PG7VL_AT: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // PG-7VM HEAT Rocket
+    class CUP_R_PG7VM_AT: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // PG-7VR (T-HEAT) Rocket
+    class CUP_R_PG7VR_AT: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // TBG-7V (Thermobaric) Rocket
+    class CUP_R_TBG7V_AT: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // RPG-26 Rocket
+    class CUP_R_PG26_AT: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
+
+    // RPG-18 Rocket
+    class CUP_R_RPG18_AT: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        airLock = 1;
+        allowAgainstInfantry = 1;
+        cost = 30;
+    };
 };

--- a/addons/ammunition/subconfig_CUP/CfgMagazines.hpp
+++ b/addons/ammunition/subconfig_CUP/CfgMagazines.hpp
@@ -55,6 +55,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_46x30";
         displayName = "Generic 40Rnd MP7 Magazine";
+        mass = 8;
     };
 
     class CUP_30Rnd_45ACP_M3A1_BLK_M;
@@ -62,6 +63,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_45ACP";
         displayName = "Generic 30Rnd M3A1 Magazine";
+        mass = 8;
     };
 
     class CUP_30Rnd_45ACP_MAC10_M;
@@ -69,6 +71,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_45ACP";
         displayName = "Generic 30Rnd MAC-10 Magazine";
+        mass = 8;
     };
 
     class CUP_64Rnd_9x19_Bizon_M;
@@ -76,6 +79,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_9x19";
         displayName = "Generic 64Rnd Bizon Magazine";
+        mass = 16;
     };
 
     class CUP_30Rnd_9x19_MP5;
@@ -83,6 +87,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_9x19";
         displayName = "Generic 30Rnd MP5 Magazine";
+        mass = 8;
     };
 
     class CUP_32Rnd_9x19_TEC9;
@@ -90,6 +95,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_9x19";
         displayName = "Generic 32Rnd TEC9 Magazine";
+        mass = 8;
     };
 
     class CUP_32Rnd_9x19_UZI_M;
@@ -97,6 +103,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_9x19";
         displayName = "Generic 32Rnd UZI Magazine";
+        mass = 8;
     };
 
     class CUP_72Rnd_9x19_UZI_M;
@@ -104,6 +111,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_9x19";
         displayName = "Generic 72Rnd UZI Magazine";
+        mass = 16;
     };
 
     class CUP_30Rnd_9x19_Vityaz;
@@ -111,6 +119,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_9x19";
         displayName = "Generic 30Rnd Vityaz Magazine";
+        mass = 8;
     };
 
     class CUP_30Rnd_9x39_SP5_VIKHR_M;
@@ -118,6 +127,7 @@ class CfgMagazines {
         MACRO_HANDGUN_MAGAZINE;
         ammo = "TACU_Ammunition_9x39";
         displayName = "Generic 30Rnd SR3M Magazine";
+        mass = 8;
     };
 
     // Assault Rifles
@@ -126,6 +136,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 30Rnd 5.56 AK Magazine";
+        mass = 9;
     };
 
     class CUP_30Rnd_556x45_AK19_M;
@@ -133,6 +144,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 30Rnd 5.56 AK19 Magazine";
+        mass = 9;
     };
 
     class CUP_30Rnd_556x45_AUG;
@@ -140,6 +152,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 30Rnd 5.56 AUG Magazine";
+        mass = 9;
     };
 
     class CUP_30Rnd_556x45_G36;
@@ -147,6 +160,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 30Rnd 5.56 G36 Magazine";
+        mass = 9;
     };
 
     class CUP_25Rnd_556x45_Famas;
@@ -154,6 +168,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 25Rnd 5.56 FAMAS Magazine";
+        mass = 8;
     };
 
     class CUP_30Rnd_545x39_Fort224_M;
@@ -161,6 +176,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 30Rnd 5.56 Fort Magazine";
+        mass = 9;
     };
 
     class CUP_30Rnd_762x39_CZ807;
@@ -168,6 +184,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_762x39";
         displayName = "Generic 30Rnd 7.62 CZ Magazine";
+        mass = 10;
     };
 
     class CUP_30Rnd_Sa58_M;
@@ -175,6 +192,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_762x39";
         displayName = "Generic 30Rnd 7.62 SA58 Magazine";
+        mass = 10;
     };
 
     // Battle Rifles / Marksman Rifles
@@ -183,6 +201,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_762x51";
         displayName = "Generic 20Rnd 7.62 FAL Magazine";
+        mass = 10;
     };
 
     class CUP_20Rnd_762x51_B_SCAR_bkl;
@@ -190,6 +209,7 @@ class CfgMagazines {
         MACRO_RIFLE_MAGAZINE;
         ammo = "TACU_Ammunition_762x51";
         displayName = "Generic 20Rnd 7.62 SCAR-H Magazine";
+        mass = 10;
     };
 
     // Machine Guns
@@ -198,6 +218,7 @@ class CfgMagazines {
         MACRO_MG_MAGAZINE;
         ammo = "TACU_Ammunition_545x39";
         displayName = "Generic 45Rnd 5.45 RPK Magazine";
+        mass = 13;
     };
 
     class CUP_60Rnd_545x39_AK74M_M;
@@ -205,6 +226,7 @@ class CfgMagazines {
         MACRO_MG_MAGAZINE;
         ammo = "TACU_Ammunition_545x39";
         displayName = "Generic 60Rnd 5.45 Quadstack Magazine";
+        mass = 14;
     };
 
     class CUP_100Rnd_556x45_BetaCMag_ar15;
@@ -212,6 +234,7 @@ class CfgMagazines {
         MACRO_MG_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 100Rnd 556 AR15 Beta-C Magazine";
+        mass = 17;
     };
 
     class CUP_100Rnd_556x45_BetaCMag;
@@ -219,6 +242,7 @@ class CfgMagazines {
         MACRO_MG_MAGAZINE;
         ammo = "TACU_Ammunition_556x45";
         displayName = "Generic 100Rnd 556 G36 Beta-C Magazine";
+        mass = 17;
     };
 
     class CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch;
@@ -233,6 +257,7 @@ class CfgMagazines {
         MACRO_MG_MAGAZINE;
         ammo = "TACU_Ammunition_762x39";
         displayName = "Generic 40Rnd 7.62 RPK Magazine";
+        mass = 12;
     };
 
     class CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M;

--- a/addons/ammunition/subconfig_CUP/CfgWeapons.hpp
+++ b/addons/ammunition/subconfig_CUP/CfgWeapons.hpp
@@ -1,5 +1,10 @@
 class CfgWeapons {
-    // Add magwells to weapons that don't have them or reliable ones.
+    /*
+     * Adds missing magwells to weapons that lack them.
+     * Alters RPG firemodes.
+    */
+
+    // Magwells
     class Pistol_Base_F;
     class Rifle_Base_F;
 
@@ -57,5 +62,20 @@ class CfgWeapons {
     class CUP_arifle_X95_Grippod;
     class CUP_arifle_Fort224_Grippod: CUP_arifle_X95_Grippod {
         magazineWell[] += {"CBA_545x39_Fort"};
+    };
+
+    // RPG Firemodes
+    class CUP_launch_RPG7V: Launcher_Base_F {
+        class Single: Mode_SemiAuto {
+            minRange = 50;
+            minRangeProbab = 0.50;
+            midRange = 500;
+            midRangeProbab = 0.40;
+            maxRange = 800;
+            maxRangeProbab = 0.30;
+            aiRateOfFire = 7;
+            aiRateOfFireDistance = 250;
+            aiRateOfFireDispersion = 7;
+        };
     };
 };


### PR DESCRIPTION
- More balanced mass values for magazines. The more AI carry, the more they shoot.
- Launchers can fire on infantry
- RPG rounds have ACE frag values
- SPG rounds have ACE frag values
- RPG firemodes have been altered.