### PR TITLE
General - Fixes

### DIFF
--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -200,14 +200,14 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         airLock = 1;
         allowAgainstInfantry = 1;
-        cost = 70; // default 200
+        cost = 50; // default 200
     };
     // RPG-42 Rocket
     class R_PG32V_F: RocketBase {
         aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         airLock = 1;
         allowAgainstInfantry = 1;
-        cost = 70; // default 100
+        cost = 50; // default 100
     };
 
     // RPG-42 HE Rocket
@@ -223,7 +223,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         airLock = 1;
         allowAgainstInfantry = 1;
-        cost = 70; // default 100
+        cost = 50; // default 100
     };
 
     // MAAWS HEAT 55 Round
@@ -231,7 +231,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         airLock = 1;
         allowAgainstInfantry = 1;
-        cost = 70; // default 100
+        cost = 50; // default 100
     };
 
     // MAAWS HE 44 Round

--- a/addons/ammunition/script_macros.hpp
+++ b/addons/ammunition/script_macros.hpp
@@ -1,4 +1,4 @@
-#define DEBUG_MODE_FULL
+//#define DEBUG_MODE_FULL
 
 #define MACRO_TRACERS \
     model = "\a3\weapons_f\data\bullettracer\tracer_red"; \

--- a/addons/ammunition/subconfig_CUP/CfgAmmo.hpp
+++ b/addons/ammunition/subconfig_CUP/CfgAmmo.hpp
@@ -54,7 +54,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         airLock = 1;
         allowAgainstInfantry = 1;
-        cost = 70; // default 100
+        cost = 50; // default 100
     };
 
     // PG-7VL (HEAT) Rocket
@@ -62,7 +62,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         airLock = 1;
         allowAgainstInfantry = 1;
-        cost = 100; // default 200
+        cost = 50; // default 200
     };
 
     // PG-7VM HEAT Rocket
@@ -70,7 +70,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         airLock = 1;
         allowAgainstInfantry = 1;
-        cost = 70; // default 100
+        cost = 50; // default 100
     };
 
     // PG-7VR (T-HEAT) Rocket
@@ -86,7 +86,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         airLock = 1;
         allowAgainstInfantry = 1;
-        cost = 150; // default 300
+        cost = 50; // default 300
     };
 
     // RPG-26 Rocket
@@ -94,7 +94,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         airLock = 1;
         allowAgainstInfantry = 1;
-        cost = 70; // default 100
+        cost = 50; // default 100
     };
 
     // RPG-18 Rocket
@@ -102,6 +102,6 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         airLock = 1;
         allowAgainstInfantry = 1;
-        cost = 100; // default 200
+        cost = 50; // default 200
     };
 };

--- a/addons/assets/script_macros.hpp
+++ b/addons/assets/script_macros.hpp
@@ -12,6 +12,7 @@
         typicalCargo[] = {"TACU_Assets_TestUnit"}
 #else
     #define MACRO_DEFAULT_VEHICLE \
+        editorPreview = ""; \
         author = "Mike"; \
         scope = 1; \
         scopeCurator = 1; \

--- a/addons/cartel_greek/CfgVehicles_Enforcers.hpp
+++ b/addons/cartel_greek/CfgVehicles_Enforcers.hpp
@@ -103,25 +103,25 @@ class TACU_Cartel_Greek_U_O_Enforcer_Rifleman_04: TACU_Cartel_Greek_U_O_Enforcer
     displayName = "Enforcer (G36K / RPG7)";
     weapons[] = {
         "TACU_Cartel_Greek_W_G36K_KSK",
-        "CUP_launch_RPG7V",
+        "launch_RPG7_F",
         "TACU_Cartel_Greek_W_M9_Laser",
         "Throw", "Put"
     };
     respawnWeapons[] = {
         "TACU_Cartel_Greek_W_G36K_KSK",
-        "CUP_launch_RPG7V",
+        "launch_RPG7_F",
         "TACU_Cartel_Greek_W_M9_Laser",
         "Throw", "Put"
     };
     magazines[] = {
         mag_11("TACU_Magazine_30Rnd_556_G36"),
-        "CUP_OG7_M",
+        "RPG7_F",
         mag_2("TACU_Magazine_15Rnd_M9"),
         mag_2("HandGrenade")
     };
     respawnMagazines[] = {
         mag_11("TACU_Magazine_30Rnd_556_G36"),
-        "CUP_OG7_M",
+        "RPG7_F",
         mag_2("TACU_Magazine_15Rnd_M9"),
         mag_2("HandGrenade")
     };


### PR DESCRIPTION
Fixes for issues found so far.

- Ammunition
    - Debug mode was still enabled, ammo shows in Arsenal.
    - Lower RPG costs to 50 (from 70 in most cases) 
- Assets
    - Removed vehicle `editorPreviews` for now.
- Greek Cartel
    - RPG unit using AP rockets but not marked as AP, just switched him to regular AT.