### PR TITLE
Fix requiredAddons for faction overwrites

### DIFF
--- a/addons/faction_overwrites/subconfig_cup/config.cpp
+++ b/addons/faction_overwrites/subconfig_cup/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
             "tacu_main",
-            "tacu_cup_ammunition",
+            "CUP_Weapons_LoadOrder",
             "CUP_Creatures_People_LoadOrder"
         };
         skipWhenMissingDependencies = 1;


### PR DESCRIPTION
- Won't recognise that `tacu_cup_ammunition` is loaded, just doing it based from weapons is fine as that's what loads ammo subconfig.