### PR TITLE
Assets - Remove WS Invisible Units

### DIFF
--- a/addons/assets/Vehicles/Otokar_ARMA_Armed.hpp
+++ b/addons/assets/Vehicles/Otokar_ARMA_Armed.hpp
@@ -88,5 +88,17 @@ class TACU_Otokar_ARMA_Armed_Base: O_APC_Wheeled_02_hmg_lxWS {
         "Sand_Desert", 1
     };
 
-    MACRO_EVENTHANDLERS;
+    class EventHandlers: EventHandlers {
+        postInit = "if (local (_this select 0)) then { [_this select 0, '', [], true] call BIS_fnc_initVehicle; };";
+
+        // Gets rid of the weird script that adds agents with no locality checks. (Recheck this after WS Patches)
+        class lxWS {
+            deleted = "";
+            getIn = "";
+            getOut = "";
+            init = "";
+            killed = "";
+            seatSwitched = "";
+        };
+    };
 };


### PR DESCRIPTION
- Otokar ARMA HMG spawns agents with no locality checks to "make AI shoot at the gunner" but it just ends up creating a bunch of agents that aren't invisible.